### PR TITLE
refactor: move output to lock-output and bump version to v0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ target/
 
 # Data
 fis-export/
+lock-output/
 geotypes.json
 
 # IPython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fis"
-version = "0.2.0"
+version = "0.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Changes
- Moved lock schematization output to `lock-output/` directory (sibling to `fis-export/`).
- Added `lock-output/` to `.gitignore`.
- Bumped version to `v0.2.1`.