### PR TITLE
Fix length_m recalculation after split for fairway segments

### DIFF
--- a/fis/lock/graph.py
+++ b/fis/lock/graph.py
@@ -1,8 +1,10 @@
 import pandas as pd
 from shapely import wkt
 from shapely.geometry import Point, mapping
+from pyproj import Geod
 from fis.lock.utils import find_chamber_doors
 
+geod = Geod(ellps="WGS84")
 
 
 def build_graph_features(complexes):
@@ -111,7 +113,8 @@ def _process_fairway_connections(c, seen_nodes, start_node, end_node, split_node
                     "name": c.get("fairway_name"),
                     "section_id": c.get("sections", [{}])[0].get("id") if c.get("sections") else None,
                     "source_node": start_node,
-                    "target_node": split_node_id
+                    "target_node": split_node_id,
+                    "length_m": round(geod.geometry_length(g_before_edges), 2)
                 }
             })
         
@@ -161,7 +164,8 @@ def _process_fairway_connections(c, seen_nodes, start_node, end_node, split_node
                 "name": c.get("fairway_name"),
                 "section_id": c.get("sections", [{}])[0].get("id") if c.get("sections") else None,
                 "source_node": merge_node_id,
-                "target_node": end_node
+                "target_node": end_node,
+                "length_m": round(geod.geometry_length(g_after_edges), 2)
             }
         })
         
@@ -276,7 +280,8 @@ def _process_chambers(c, split_node_id, merge_node_id, split_point, merge_point)
                         "name": c.get("fairway_name"),
                         "section_id": c.get("sections", [{}])[0].get("id") if c.get("sections") else None,
                         "source_node": split_node_id,
-                        "target_node": chamber_node_start_id
+                        "target_node": chamber_node_start_id,
+                        "length_m": round(geod.geometry_length(approach_line), 2)
                     }
                 })
                  
@@ -295,7 +300,8 @@ def _process_chambers(c, split_node_id, merge_node_id, split_point, merge_point)
                         "name": c.get("fairway_name"),
                         "section_id": c.get("sections", [{}])[0].get("id") if c.get("sections") else None,
                         "source_node": chamber_node_start_id,
-                        "target_node": chamber_node_end_id
+                        "target_node": chamber_node_end_id,
+                        "length_m": round(geod.geometry_length(chamber_line), 2)
                     }
                 })
                  
@@ -314,7 +320,8 @@ def _process_chambers(c, split_node_id, merge_node_id, split_point, merge_point)
                          "name": c.get("fairway_name"),
                          "section_id": c.get("sections", [{}])[0].get("id") if c.get("sections") else None,
                          "source_node": chamber_node_end_id,
-                         "target_node": merge_node_id
+                         "target_node": merge_node_id,
+                         "length_m": round(geod.geometry_length(exit_line), 2)
                      }
                  })
 
@@ -349,7 +356,8 @@ def _process_chambers(c, split_node_id, merge_node_id, split_point, merge_point)
                              "fairway_id": c.get("fairway_id"),
                              "source_node": split_node_id,
                              "target_node": merge_node_id, 
-                             "intermediate_node": chamber_node_id
+                             "intermediate_node": chamber_node_id,
+                             "length_m": round(geod.geometry_length(wkt.loads(chamber["route_geometry"])), 2)
                          }
                      })
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "tabulate>=0.9.0",
 ]
 
+[project.scripts]
+fis = "fis.cli:cli"
+
 [dependency-groups]
 dev = [
     "ipdb>=0.13.13",


### PR DESCRIPTION
Fixes issue #20 (Subissue of #15) by using pyproj.Geod to recalculate length_m for fairway segments and chamber routes after they are split by a lock. Also exposes the fis cli in pyproject.toml.