### PR TITLE
Export EURIS nodes and edges as geoparquet and include ris-index

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -130,6 +130,7 @@ jobs:
             output/fis-graph/*.geoparquet
             output/euris-graph/*.pickle
             output/euris-graph/*.geoparquet
+            output/euris-graph/*.gpkg
             output/merged-graph/*.pickle
             output/merged-graph/*.geoparquet
             output/lock-schematization/*.geoparquet


### PR DESCRIPTION
Resolves request to expose `nodes.geoparquet`, `edges.geoparquet`, and `ris-index.gpkg` from the EURIS graph build instead of shipping the raw export.