### PR TITLE
Fix Scrapy deprecation warning in DataserviceSpider

### DIFF
--- a/fis/spiders/dataservice.py
+++ b/fis/spiders/dataservice.py
@@ -46,7 +46,7 @@ class DataserviceSpider(scrapy.Spider):
         )
         return spider
 
-    def start_requests(self):
+    async def start(self):
         yield scrapy.Request(url=self.wadl_url, callback=self.parse_waml)
 
     def parse_waml(self, response):


### PR DESCRIPTION
Replaced `start_requests()` with `async def start()` in `DataserviceSpider` to resolve the `ScrapyDeprecationWarning` introduced in Scrapy 2.13.