### PR TITLE
docs: document lock schematization design, use cases, and output structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,54 @@
 ## Repository Overview
 
-This repository is a data processing and scraping project focused on inland waterway information.
+This repository crawls, processes, and exports inland waterway network data for transport modelling of Dutch and European inland waterways. It produces consistent, ready-to-use network graphs and lock schematizations for use in navigation and traffic simulation tools.
+
+## Use Cases
+
+### Route Assignment (Traffic Modelling)
+Locks are modelled as **delay elements** in a network graph: ships traverse the lock as a weighted edge, with the delay representing average processing time. Used in macroscopic traffic assignment studies where individual vessel queues are not simulated. Models: **BIVAS**, **OpenTNSim**.
+
+### Detailed Lock Analysis (Discrete Event Simulation)
+Locks are modelled in full detail: individual chambers, approach segments, waiting berths, and door positions. Ships queue, request a chamber, and transit step by step. Used for capacity studies and bottleneck analysis. Models: **SIVAK**, **OpenTNSim**.
+
+## Network Coverage
+
+| Network | Crawler | Description |
+|---------|---------|-------------|
+| FIS | `scrapy crawl dataservice` | Dutch inland waterways (Rijkswaterstaat) |
+| EURIS | `scrapy crawl euris` | European inland waterways |
+| Merged | `fis.cli graph merge` | Combined FIS + EURIS cross-border network |
+
+Studies may use FIS only, EURIS only, or the merged network depending on scope.
+
+## Pipeline Architecture
+
+```
+CRAWL → NETWORKS → ENRICH → SCHEMATIZE → MERGE
+```
+
+| Stage | Command | Output |
+|-------|---------|--------|
+| Crawl FIS | `scrapy crawl dataservice` | `output/fis-export/` |
+| Crawl EURIS | `scrapy crawl euris` | `output/euris-export/` |
+| Build Networks | `fis.cli graph {fis,euris}` | `output/{fis,euris}-graph/` |
+| Enrich | `fis.cli graph enrich-{fis,euris}` | `output/{fis,euris}-enriched/` |
+| Schematize Locks | `fis.cli lock schematize` | `output/lock-schematization/` |
+| Merge | `fis.cli graph merge` | `output/merged-graph/` |
+
+### Lock Schematization
+
+The lock schematization step produces **drop-in replacement subgraphs** for the sections of the network that contain locks. The nodes and edges it generates replace the corresponding fairway stretch in the routing network, adding chamber-level detail for discrete event simulation use cases.
+
+## Output File Formats
+
+All spatial outputs are produced in two formats:
+
+| Format | Extension | Use |
+|--------|-----------|-----|
+| GeoJSON | `.geojson` | Interoperability, GIS tools, human-readable |
+| GeoParquet | `.geoparquet` | Efficient storage and loading in Python (GeoPandas) |
+
+Graph outputs follow the `nodes.geoparquet` / `edges.geoparquet` convention used across all pipeline stages.
 
 ## CLI Usage
 

--- a/fis/lock/README.md
+++ b/fis/lock/README.md
@@ -1,6 +1,20 @@
 # Lock Schematization
 
-This module processes FIS lock data into detailed graph features for navigation networks.
+This module processes FIS lock data into detailed subgraph features for navigation network modelling.
+Lock schematization outputs are **drop-in replacement subgraphs**: the generated nodes and edges replace
+the corresponding fairway stretch in the routing network (FIS, EURIS, or merged) wherever a lock is present.
+
+## Use Cases
+
+### Route Assignment (Traffic Modelling)
+Only the coarse structure is needed: a `before` edge, one edge per chamber, and an `after` edge,
+together with their connecting nodes. The edge weight (delay) represents average lock processing time.
+Suitable for models such as **BIVAS** and **OpenTNSim**.
+
+### Discrete Event Simulation (Detailed Lock Analysis)
+The full detail is needed: split/merge nodes, individual chamber approach/route/exit edges,
+waiting berths, and chamber dimensions. Ships queue and transit step by step through the model.
+Suitable for models such as **SIVAK** and **OpenTNSim**.
 
 ## Usage
 
@@ -9,36 +23,46 @@ uv run python -m fis.cli lock schematize
 ```
 
 ### Options
-- `--export-dir`: Input directory (default: `output/fis-export`)
-- `--output-dir`: Output directory (default: `output/lock-schematization`)
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--export-dir` | `output/fis-export` | Input directory with parquet/geoparquet files |
+| `--fis-graph` | `output/fis-graph/graph.pickle` | FIS network graph for topology matching |
+| `--output-dir` | `output/lock-schematization` | Output directory |
 
-## Output
+## Output Files
+
+All spatial outputs are produced in two formats: `.geojson` (GIS / interoperability) and `.geoparquet`
+(efficient Python loading). File names follow the same convention as `fis-enriched`:
 
 | File | Description |
 |------|-------------|
-| `lock_schematization.json` | Full hierarchical lock complex data |
-| `lock_schematization.geojson` | Flattened GeoJSON features |
-| `lock_schematization.geoparquet` | Flattened GeoParquet features |
+| `nodes.geojson` / `.geoparquet` | Routing nodes: junctions, split/merge points, chamber doors |
+| `edges.geojson` / `.geoparquet` | Routing edges: fairway segments and chamber routes |
+| `berths.geojson` / `.geoparquet` | Waiting berths associated with each lock |
+| `summary.json` | Per-lock metadata: name, ISRS code, fairway, chamber count, berth count |
 
-## Feature Types
+> **Note:** The current implementation outputs a single flat `lock_schematization.geoparquet` /
+> `.geojson` / `.json`. The split-file structure above is the intended target (tracked in issue #17).
 
-| Type | `feature_type` | Description |
-|------|----------------|-------------|
-| Lock | `lock` | Lock complex polygon |
-| Chamber | `chamber` | Individual chamber polygon |
-| Berth | `berth` | Waiting area |
-| Segment | `fairway_segment` | Sailing path LineString |
-| Node | `node` | Topological point |
+## Node Types (`node_type`)
 
-### Segment Types (`segment_type`)
-- `before` / `after`: Main fairway segments
-- `chamber_approach`: Split → Chamber Start
-- `chamber_route`: Chamber Start → Chamber End
-- `chamber_exit`: Chamber End → Merge
+| Type | Description |
+|------|-------------|
+| `junction` | Existing FIS network junction (start/end of the lock's fairway) |
+| `lock_split` | Divergence point where chamber routes branch off |
+| `lock_merge` | Convergence point where chamber routes rejoin |
+| `chamber_start` | Chamber entrance (door position) |
+| `chamber_end` | Chamber exit (door position) |
 
-### Node Types (`node_type`)
-- `lock_split` / `lock_merge`: Divergence/convergence points
-- `chamber_start` / `chamber_end`: Chamber entrance/exit
+## Edge Types (`segment_type`)
+
+| Type | Description |
+|------|-------------|
+| `before` | Fairway approaching the lock (junction → split) |
+| `after` | Fairway leaving the lock (merge → junction) |
+| `chamber_approach` | Approach lane from split node to chamber entrance |
+| `chamber_route` | Transit through the chamber (start → end) |
+| `chamber_exit` | Exit lane from chamber exit to merge node |
 
 ## Module Structure
 
@@ -46,7 +70,7 @@ uv run python -m fis.cli lock schematize
 fis/lock/
 ├── __init__.py
 ├── cli.py      # CLI commands
-├── core.py     # Data loading and grouping
-├── graph.py    # Feature generation
-└── utils.py    # Geometry utilities
+├── core.py     # Data loading, lock grouping, berth/section association
+├── graph.py    # Node/edge feature generation
+└── utils.py    # Geometry utilities (door finding, etc.)
 ```


### PR DESCRIPTION
Documents the design decisions and intended output structure discussed in #17.

## Changes

- **`README.md`**: Expanded with use cases (route assignment / discrete event simulation), downstream models (SIVAK, OpenTNSim, BIVAS), network coverage (FIS / EURIS / merged), lock schematization design intent as drop-in replacement subgraphs, and output file format convention (`.geojson` + `.geoparquet`).

- **`fis/lock/README.md`**: Rewrote to document the target output file structure (`nodes`, `edges`, `berths`, `summary.json`), node/edge type tables, and a note that the current flat output (`lock_schematization.*`) is the migration target tracked in #17.

Closes #17 (partially — documents the design; code changes tracked separately).