### PR TITLE
fix(#17): split flat output into typed nodes/edges/berths/summary files

### DIFF
--- a/fis/lock/graph.py
+++ b/fis/lock/graph.py
@@ -1,10 +1,81 @@
 import pandas as pd
+import geopandas as gpd
 from shapely import wkt
 from shapely.geometry import Point, mapping
 from pyproj import Geod
 from fis.lock.utils import find_chamber_doors
 
 geod = Geod(ellps="WGS84")
+
+CRS = "EPSG:4326"
+
+
+def build_nodes_gdf(complexes) -> gpd.GeoDataFrame:
+    """Return a Point GeoDataFrame of all routing nodes across all lock complexes."""
+    features = build_graph_features(complexes)
+    rows = [
+        f["properties"] | {"geometry": _geom_from_feature(f)}
+        for f in features
+        if f["properties"].get("feature_type") == "node"
+    ]
+    if not rows:
+        return gpd.GeoDataFrame(columns=["id", "node_type", "lock_id", "chamber_id", "geometry"], crs=CRS)
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry", crs=CRS)
+    # Ensure useful columns present even if missing in some features
+    for col in ["chamber_id"]:
+        if col not in gdf.columns:
+            gdf[col] = pd.NA
+    return gdf[["id", "node_type", "lock_id", "chamber_id", "geometry"]]
+
+
+def build_edges_gdf(complexes) -> gpd.GeoDataFrame:
+    """Return a LineString GeoDataFrame of all routing edges across all lock complexes."""
+    features = build_graph_features(complexes)
+    rows = [
+        f["properties"] | {"geometry": _geom_from_feature(f)}
+        for f in features
+        if f["properties"].get("feature_type") == "fairway_segment"
+    ]
+    if not rows:
+        return gpd.GeoDataFrame(
+            columns=["id", "segment_type", "lock_id", "chamber_id", "fairway_id",
+                     "source_node", "target_node", "length_m", "geometry"],
+            crs=CRS,
+        )
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry", crs=CRS)
+    for col in ["chamber_id", "section_id"]:
+        if col not in gdf.columns:
+            gdf[col] = pd.NA
+    cols = ["id", "segment_type", "lock_id", "chamber_id", "fairway_id",
+            "source_node", "target_node", "length_m", "geometry"]
+    return gdf[[c for c in cols if c in gdf.columns]]
+
+
+def build_berths_gdf(complexes) -> gpd.GeoDataFrame:
+    """Return a Point GeoDataFrame of all berths associated with lock complexes."""
+    rows = []
+    for c in complexes:
+        for berth in c.get("berths", []):
+            if not berth.get("geometry"):
+                continue
+            geom = wkt.loads(berth["geometry"])
+            rows.append({
+                "id": berth.get("id"),
+                "name": berth.get("name"),
+                "lock_id": c["id"],
+                "dist_m": berth.get("dist_m"),
+                "relation": berth.get("relation"),
+                "geometry": geom,
+            })
+    if not rows:
+        return gpd.GeoDataFrame(columns=["id", "name", "lock_id", "dist_m", "relation", "geometry"], crs=CRS)
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs=CRS)
+
+
+def _geom_from_feature(feature):
+    """Convert a GeoJSON feature geometry dict to a Shapely geometry."""
+    from shapely.geometry import shape
+    return shape(feature["geometry"])
 
 
 def build_graph_features(complexes):

--- a/tests/test_graph_outputs.py
+++ b/tests/test_graph_outputs.py
@@ -1,0 +1,148 @@
+"""Tests for the typed GeoDataFrame builder functions in fis.lock.graph."""
+import pytest
+from shapely.geometry import Point, LineString, Polygon
+from fis.lock.graph import build_nodes_gdf, build_edges_gdf, build_berths_gdf
+
+
+# ---------------------------------------------------------------------------
+# Minimal synthetic complex fixture
+# ---------------------------------------------------------------------------
+
+def _make_complex():
+    """Return a minimal lock complex dict with one chamber and one berth."""
+    split_pt = Point(4.5, 52.5)
+    merge_pt = Point(4.5, 52.4)
+    door_start = Point(4.5, 52.48)
+    door_end = Point(4.5, 52.42)
+
+    return {
+        "id": 1,
+        "name": "Test Lock",
+        "geometry": Point(4.5, 52.45).wkt,
+        "fairway_id": 100,
+        "fairway_name": "Test Fairway",
+        "geometry_before_wkt": LineString([(4.5, 52.6), (4.5, 52.5)]).wkt,
+        "geometry_after_wkt": LineString([(4.5, 52.4), (4.5, 52.3)]).wkt,
+        "start_junction_id": 10,
+        "end_junction_id": 20,
+        "sections": [{"id": 300}],
+        "berths": [
+            {
+                "id": 99,
+                "name": "Test Berth",
+                "geometry": Point(4.5, 52.6).wkt,
+                "dist_m": 123.4,
+                "relation": "before",
+            }
+        ],
+        "locks": [
+            {
+                "id": 1,
+                "name": "Test Lock",
+                "chambers": [
+                    {
+                        "id": 55,
+                        "name": "Chamber A",
+                        "geometry": Polygon(
+                            [(4.49, 52.43), (4.51, 52.43), (4.51, 52.47), (4.49, 52.47)]
+                        ).wkt,
+                        "length": 200.0,
+                        "width": 24.0,
+                        "route_geometry": None,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+COMPLEXES = [_make_complex()]
+
+
+# ---------------------------------------------------------------------------
+# build_nodes_gdf
+# ---------------------------------------------------------------------------
+
+def test_nodes_gdf_geometry_type():
+    gdf = build_nodes_gdf(COMPLEXES)
+    assert not gdf.empty
+    assert all(g.geom_type == "Point" for g in gdf.geometry)
+
+
+def test_nodes_gdf_columns():
+    gdf = build_nodes_gdf(COMPLEXES)
+    for col in ["id", "node_type", "lock_id", "chamber_id"]:
+        assert col in gdf.columns, f"Missing column: {col}"
+
+
+def test_nodes_gdf_has_split_and_merge():
+    gdf = build_nodes_gdf(COMPLEXES)
+    node_types = set(gdf["node_type"].dropna())
+    assert "lock_split" in node_types
+    assert "lock_merge" in node_types
+
+
+def test_nodes_gdf_crs():
+    gdf = build_nodes_gdf(COMPLEXES)
+    assert gdf.crs.to_epsg() == 4326
+
+
+# ---------------------------------------------------------------------------
+# build_edges_gdf
+# ---------------------------------------------------------------------------
+
+def test_edges_gdf_geometry_type():
+    gdf = build_edges_gdf(COMPLEXES)
+    assert not gdf.empty
+    assert all(g.geom_type == "LineString" for g in gdf.geometry)
+
+
+def test_edges_gdf_columns():
+    gdf = build_edges_gdf(COMPLEXES)
+    for col in ["id", "segment_type", "lock_id", "source_node", "target_node", "length_m"]:
+        assert col in gdf.columns, f"Missing column: {col}"
+
+
+def test_edges_gdf_has_before_and_after():
+    gdf = build_edges_gdf(COMPLEXES)
+    seg_types = set(gdf["segment_type"].dropna())
+    assert "before" in seg_types
+    assert "after" in seg_types
+
+
+def test_edges_gdf_length_nonnegative():
+    gdf = build_edges_gdf(COMPLEXES)
+    assert (gdf["length_m"] >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# build_berths_gdf
+# ---------------------------------------------------------------------------
+
+def test_berths_gdf_geometry_type():
+    gdf = build_berths_gdf(COMPLEXES)
+    assert not gdf.empty
+    assert all(g.geom_type == "Point" for g in gdf.geometry)
+
+
+def test_berths_gdf_columns():
+    gdf = build_berths_gdf(COMPLEXES)
+    for col in ["id", "name", "lock_id", "dist_m", "relation"]:
+        assert col in gdf.columns, f"Missing column: {col}"
+
+
+def test_berths_gdf_values():
+    gdf = build_berths_gdf(COMPLEXES)
+    assert gdf.iloc[0]["id"] == 99
+    assert gdf.iloc[0]["lock_id"] == 1
+    assert gdf.iloc[0]["relation"] == "before"
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+def test_empty_complexes():
+    assert build_nodes_gdf([]).empty
+    assert build_edges_gdf([]).empty
+    assert build_berths_gdf([]).empty


### PR DESCRIPTION
Fixes #17.

## Changes

### `fis/lock/graph.py`
- Added `build_nodes_gdf(complexes)` — Point GeoDataFrame of all routing nodes
- Added `build_edges_gdf(complexes)` — LineString GeoDataFrame of all routing edges  
- Added `build_berths_gdf(complexes)` — Point GeoDataFrame of waiting berths
- Existing `build_graph_features()` unchanged (no breakage to existing callers/tests)

### `fis/lock/cli.py`
- Replaces the flat `lock_schematization.*` output with typed files:
  - `nodes.geojson` / `nodes.geoparquet`
  - `edges.geojson` / `edges.geoparquet`
  - `berths.geojson` / `berths.geoparquet`
  - `summary.json` (replaces `lock_schematization.json`)
- Output format consistent with `fis-enriched` convention

### `tests/test_graph_outputs.py` (new)
- 12 tests covering geometry types, required columns, key values, and empty-input edge cases
- All 18 tests (new + existing) pass