### PR TITLE
fix: resolve ruff linting errors to fix CI

### DIFF
--- a/fis/lock/core.py
+++ b/fis/lock/core.py
@@ -4,6 +4,8 @@ import pandas as pd
 import geopandas as gpd
 from shapely import wkt
 from tqdm import tqdm
+from shapely.geometry.base import BaseGeometry
+import numpy as np
 
 from shapely.geometry import Point, LineString
 
@@ -78,10 +80,6 @@ def load_data(export_dir: pathlib.Path, disk_dir: pathlib.Path):
         bridges,
         openings,
     )
-
-
-from shapely.geometry.base import BaseGeometry
-import numpy as np
 
 
 def to_python(obj):
@@ -174,15 +172,15 @@ def match_disk_objects(lock, lock_chambers, disk_locks_rd, disk_bridges_rd):
             )
             if chamber_union_rd:
                 lock_mask_strict = disk_locks_rd.intersects(chamber_union_rd)
-                for _, l in disk_locks_rd[lock_mask_strict].iterrows():
-                    matched_disk_locks.append(sanitize_attrs(l))
+                for _, lock_row in disk_locks_rd[lock_mask_strict].iterrows():
+                    matched_disk_locks.append(sanitize_attrs(lock_row))
 
             # 2. If NO locks matched via chambers, fallback to 500m lock complex buffer
             if not matched_disk_locks and lock_geom_rd:
                 lock_buffer_rd = lock_geom_rd.buffer(500)
                 lock_mask_loose = disk_locks_rd.intersects(lock_buffer_rd)
-                for _, l in disk_locks_rd[lock_mask_loose].iterrows():
-                    matched_disk_locks.append(sanitize_attrs(l))
+                for _, lock_row in disk_locks_rd[lock_mask_loose].iterrows():
+                    matched_disk_locks.append(sanitize_attrs(lock_row))
 
     return matched_disk_locks, matched_disk_bridges
 

--- a/fis/spiders/disk.py
+++ b/fis/spiders/disk.py
@@ -24,18 +24,20 @@ class DiskSpider(scrapy.Spider):
     allowed_domains = ["geo.rijkswaterstaat.nl"]
 
     base_url = "https://geo.rijkswaterstaat.nl/services/ogc/gdr/disk_beheerobjecten/ows?service=WFS&version=2.0.0&request=GetFeature&outputFormat=application/json"
-    
+
     layers = [
         "disk_beheerobjecten:schutsluis",
         "disk_beheerobjecten:keersluis",
         "disk_beheerobjecten:spuisluis",
         "disk_beheerobjecten:brug_beweegbaar",
-        "disk_beheerobjecten:brug_vast"
+        "disk_beheerobjecten:brug_vast",
     ]
 
     @property
     def data_dir(self):
-        data_dir = pathlib.Path(self.settings.get("DISK_EXPORT_DIR", "output/disk-export"))
+        data_dir = pathlib.Path(
+            self.settings.get("DISK_EXPORT_DIR", "output/disk-export")
+        )
         data_dir = data_dir.expanduser()
         data_dir.mkdir(exist_ok=True, parents=True)
         return data_dir
@@ -53,13 +55,14 @@ class DiskSpider(scrapy.Spider):
         # We don't actually need Scrapy to make async HTTP requests if we use owslib
         # but to keep it within the Scrapy lifecycle, we can just yield a dummy request
         # and do the work in the callback, or just do the work here and yield items.
-        
+
         from owslib.wfs import WebFeatureService
-        import io
-        
-        wfs_url = "https://geo.rijkswaterstaat.nl/services/ogc/gdr/disk_beheerobjecten/ows"
+
+        wfs_url = (
+            "https://geo.rijkswaterstaat.nl/services/ogc/gdr/disk_beheerobjecten/ows"
+        )
         try:
-            wfs = WebFeatureService(url=wfs_url, version='2.0.0')
+            wfs = WebFeatureService(url=wfs_url, version="2.0.0")
         except Exception as e:
             self.logger.error("Failed to connect to WFS: %s", e)
             return
@@ -68,27 +71,30 @@ class DiskSpider(scrapy.Spider):
             geo_type = layer.split(":")[1]
             try:
                 self.logger.info("Fetching WFS layer: %s", layer)
-                response = wfs.getfeature(typename=layer, outputFormat='application/json')
-                
+                response = wfs.getfeature(
+                    typename=layer, outputFormat="application/json"
+                )
+
                 # The response is a file-like object containing GeoJSON bytes
                 geojson_data = response.read()
                 resp_json = json.loads(geojson_data)
                 features = resp_json.get("features", [])
-                
+
                 for feature in features:
                     props = feature.get("properties", {})
                     geom = feature.get("geometry")
-                    
+
                     row = {**props}
-                    
+
                     from shapely.geometry import shape
+
                     if geom:
                         try:
                             s = shape(geom)
                             row["Geometry"] = s.wkt
                         except Exception:
                             row["Geometry"] = None
-                            
+
                     row["GeoType"] = geo_type
                     yield row
             except Exception as e:
@@ -116,7 +122,7 @@ class DiskSpider(scrapy.Spider):
                 gdf = gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:28992")
                 # Convert to standard WGS84 (EPSG:4326)
                 gdf = gdf.to_crs("EPSG:4326")
-                
+
                 # Re-assign back to WKT string for standard json/parquet serializers
                 df["Geometry"] = gdf.geometry.to_wkt()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -200,7 +200,7 @@ def test_find_nearby_berths_relation():
 def test_sanitize_attrs():
     import numpy as np
     from shapely.geometry import Point
-    
+
     raw = {
         "A": np.int64(42),
         "B": np.float64(3.14),
@@ -208,7 +208,7 @@ def test_sanitize_attrs():
         "geometry": Point(0, 0),
         "D": pd.NaT,
         "E": pd.Timestamp("2020-01-01"),
-        "F": np.bool_(True)
+        "F": np.bool_(True),
     }
     sanitized = sanitize_attrs(raw)
     assert sanitized["A"] == 42
@@ -225,54 +225,60 @@ def test_sanitize_attrs():
 def test_match_disk_objects():
     # Construct lock and chambers in EPSG:4326 (Roughly central NL)
     lock_geom = Point(5.0, 52.0)
-    
-    lock_row = pd.Series({
-        "Id": 1,
-        "Name": "Test Complex",
-        "geometry": lock_geom
-    })
+
+    lock_row = pd.Series({"Id": 1, "Name": "Test Complex", "geometry": lock_geom})
 
     # A square chamber roughly 100x100m (0.001 deg is ~110m)
-    chamber_geom = Polygon([
-        (4.999, 51.999),
-        (5.001, 51.999),
-        (5.001, 52.001),
-        (4.999, 52.001),
-        (4.999, 51.999)
-    ])
-    
-    chambers_df = pd.DataFrame([{
-        "Id": 10,
-        "ParentId": 1,
-        "geometry": chamber_geom.wkt
-    }])
+    chamber_geom = Polygon(
+        [
+            (4.999, 51.999),
+            (5.001, 51.999),
+            (5.001, 52.001),
+            (4.999, 52.001),
+            (4.999, 51.999),
+        ]
+    )
+
+    chambers_df = pd.DataFrame(
+        [{"Id": 10, "ParentId": 1, "geometry": chamber_geom.wkt}]
+    )
 
     # Project the chamber to RD to figure out where to place the DISK points
-    chamber_rd = gpd.GeoSeries([chamber_geom], crs="EPSG:4326").to_crs("EPSG:28992").iloc[0]
-    
+    chamber_rd = (
+        gpd.GeoSeries([chamber_geom], crs="EPSG:4326").to_crs("EPSG:28992").iloc[0]
+    )
+
     # 1. DISK Lock exactly inside chamber (strict match)
     disk_lock_in = chamber_rd.centroid
-    
+
     # 2. DISK Lock outside chamber, but within 500m of lock centroid (e.g. +200m)
     disk_lock_near = Point(disk_lock_in.x + 200, disk_lock_in.y)
-    
+
     # 3. DISK Bridge within 500m buffer (e.g. +300m)
     disk_bridge_near = Point(disk_lock_in.x + 300, disk_lock_in.y)
 
     # 4. DISK Lock outside 500m buffer (e.g. +1000m)
     disk_lock_far = Point(disk_lock_in.x + 1000, disk_lock_in.y)
 
-    disk_locks_rd = gpd.GeoDataFrame([
-        {"id": 100, "name": "Inside Chamber", "geometry": disk_lock_in},
-        {"id": 200, "name": "Near Lock Buffer", "geometry": disk_lock_near},
-        {"id": 300, "name": "Far Lock", "geometry": disk_lock_far},
-    ], geometry="geometry", crs="EPSG:28992")
+    disk_locks_rd = gpd.GeoDataFrame(
+        [
+            {"id": 100, "name": "Inside Chamber", "geometry": disk_lock_in},
+            {"id": 200, "name": "Near Lock Buffer", "geometry": disk_lock_near},
+            {"id": 300, "name": "Far Lock", "geometry": disk_lock_far},
+        ],
+        geometry="geometry",
+        crs="EPSG:28992",
+    )
 
-    disk_bridges_rd = gpd.GeoDataFrame([
-        {"id": 400, "name": "Near Bridge", "geometry": disk_bridge_near}
-    ], geometry="geometry", crs="EPSG:28992")
+    disk_bridges_rd = gpd.GeoDataFrame(
+        [{"id": 400, "name": "Near Bridge", "geometry": disk_bridge_near}],
+        geometry="geometry",
+        crs="EPSG:28992",
+    )
 
-    matched_locks, matched_bridges = match_disk_objects(lock_row, chambers_df, disk_locks_rd, disk_bridges_rd)
+    matched_locks, matched_bridges = match_disk_objects(
+        lock_row, chambers_df, disk_locks_rd, disk_bridges_rd
+    )
 
     # Strict matching prioritizes the lock inside the chamber!
     # Because there's a strict match, fallback is skipped.
@@ -285,8 +291,10 @@ def test_match_disk_objects():
 
     # Test fallback: Remove the strict match
     disk_locks_rd_fallback = disk_locks_rd.iloc[1:3]  # Only Near and Far
-    matched_locks_fallback, _ = match_disk_objects(lock_row, chambers_df, disk_locks_rd_fallback, disk_bridges_rd)
-    
+    matched_locks_fallback, _ = match_disk_objects(
+        lock_row, chambers_df, disk_locks_rd_fallback, disk_bridges_rd
+    )
+
     # Now the Near lock should match via 500m buffer, and Far should be excluded
     assert len(matched_locks_fallback) == 1
     assert matched_locks_fallback[0]["id"] == 200


### PR DESCRIPTION
Fixes a few E402, E741, and F401 linting errors that broke the CI after the recent lock schematization refactors in PR #50 and #51.