### PR TITLE
fix: add missing owslib dependency for disk spider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "jupyterlab>=4.4.3",
     "networkx>=3.5",
     "openpyxl>=3.1.5",
+    "owslib>=0.35.0",
     "pandas>=2.3.0",
     "pyarrow>=21.0.0",
     "scrapy>=2.13.2",


### PR DESCRIPTION
The newly added DISK spider relies on `owslib` to query the WFS endpoint, but it wasn't listed in `pyproject.toml`. This commit adds `owslib` to the project dependencies to fix the CI/CD pipeline crawler step.