### PR TITLE
docs: make READMEs more beginner friendly and consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This repository crawls, processes, and exports inland waterway network data for transport modelling of Dutch and European inland waterways. It produces consistent, ready-to-use network graphs and lock schematizations for use in navigation and traffic simulation tools.
 
+## Prerequisites & Installation
+
+This project uses [`uv`](https://docs.astral.sh/uv/) for fast Python package and environment management.
+
+1. **Install `uv`**: Follow the [official installation guide](https://docs.astral.sh/uv/getting-started/installation/) or run:
+   ```bash
+   # On macOS and Linux
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   
+   # On Windows
+   powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+   ```
+
+2. **Sync the environment**: From the repository root, install dependencies and set up the virtual environment:
+   ```bash
+   uv sync
+   ```
+   This ensures all required packages are installed. You can now use `uv run` to execute commands automatically within this environment.
+
 ## Use Cases
 
 ### Route Assignment (Traffic Modelling)
@@ -34,7 +53,7 @@ CRAWL → NETWORKS → ENRICH → SCHEMATIZE → MERGE
 | Crawl EURIS | `scrapy crawl euris` | `output/euris-export/` |
 | Build Networks | `fis.cli graph {fis,euris}` | `output/{fis,euris}-graph/` |
 | Enrich | `fis.cli graph enrich-{fis,euris}` | `output/{fis,euris}-enriched/` |
-| Schematize Locks | `fis.cli lock schematize` | `output/lock-schematization/` |
+| Schematize Locks | `fis.cli lock schematize --disk-dir output/disk-export` | `output/lock-schematization/` |
 | Merge | `fis.cli graph merge` | `output/merged-graph/` |
 
 ### Lock Schematization
@@ -82,21 +101,6 @@ uv run scrapy crawl disk -L INFO
 uv run scrapy crawl euris -L INFO
 ```
 
-## Pipeline Architecture
-
-```
-CRAWL → NETWORKS → ENRICH → SCHEMATIZE → MERGE
-```
-
-| Stage | Command | Output |
-|-------|---------|--------|
-| Crawl FIS | `scrapy crawl dataservice` | `output/fis-export/` |
-| Crawl DISK | `scrapy crawl disk` | `output/disk-export/` |
-| Crawl EURIS | `scrapy crawl euris` | `output/euris-export/` |
-| Build Networks | `fis.cli graph {fis,euris}` | `output/{fis,euris}-graph/` |
-| Enrich | `fis.cli graph enrich-{fis,euris}` | `output/{fis,euris}-enriched/` |
-| Schematize Locks | `fis.cli lock schematize --disk-dir output/disk-export` | `output/lock-schematization/` |
-| Merge | `fis.cli graph merge` | `output/merged-graph/` |
 
 ## Module Documentation
 

--- a/fis/graph/README.md
+++ b/fis/graph/README.md
@@ -2,6 +2,8 @@
 
 Build network graphs from FIS (Dutch) and EURIS (European) fairway data.
 
+> **Note:** Ensure you have installed prerequisites (`uv`) and run `uv sync` from the repository root before running these commands. See the [main README](../../README.md) for details.
+
 ## Data Flow
 
 ```
@@ -54,8 +56,7 @@ output/                      # All generated data
 ├── euris-export/            # Raw EURIS data (scrapy: euris)
 │   ├── SailingSpeed_*.geojson
 │   ├── FairwaySection_*.geojson
-│   └── v0.1.0/
-│       └── export-graph-v0.1.0.pickle
+│   └── Node_*.geojson
 ├── fis-graph/               # Basic FIS graph
 ├── euris-graph/             # Basic EURIS graph
 ├── fis-enriched/            # Enriched FIS

--- a/fis/lock/README.md
+++ b/fis/lock/README.md
@@ -4,6 +4,8 @@ This module processes FIS lock data into detailed subgraph features for navigati
 Lock schematization outputs are **drop-in replacement subgraphs**: the generated nodes and edges replace
 the corresponding fairway stretch in the routing network (FIS, EURIS, or merged) wherever a lock is present.
 
+> **Note:** Ensure you have installed prerequisites (`uv`) and run `uv sync` from the repository root before running these commands. See the [main README](../../README.md) for details.
+
 ## Use Cases
 
 ### Route Assignment (Traffic Modelling)

--- a/notebooks/euris/README.md
+++ b/notebooks/euris/README.md
@@ -2,6 +2,8 @@
 
 This dataset contains a graph representation of the European River Information Services (EURIS) network, designed for inland waterway transport modeling.
 
+> **Note:** For instructions on how to set up the environment and run the pipeline to generate this data, please see the [main README](../../README.md).
+
 ## Disclaimer
 
 This dataset is an extract of the original data hosted on the EURIS platform and is intended for **research purposes only**. It should **not** be used for navigational purposes. For official and up-to-date information, please refer to the [EuRIS Portal](https://eurisportal.eu).
@@ -52,7 +54,7 @@ Edges represent the fairway sections connecting the nodes. Key attributes includ
 
 This dataset includes the following files:
 
-*   `export-nodes-v0.1.0.geojson`: A GeoJSON file containing the geographic points for all nodes in the network.
-*   `export-edges-v0.1.0.geojson`: A GeoJSON file containing the geographic lines for all edges (fairway sections) in the network.
-*   `export-graph-v0.1.0.pickle`: A Python pickle file containing a `networkx` graph object, which includes all nodes, edges, and their attributes, representing the complete waterway network.
-*   `ris_index_v0.1.0.gpkg`: A GeoPackage file related to the River Information Services (RIS) index. For more information on this data, see the [RIS Index API documentation](https://eurisportal.eu/ris-index-api-documentation).
+*   `nodes.geojson` / `nodes.geoparquet`: Files containing the geographic points for all nodes in the network.
+*   `edges.geojson` / `edges.geoparquet`: Files containing the geographic lines for all edges (fairway sections) in the network.
+*   `graph.pickle`: A Python pickle file containing a `networkx` graph object, which includes all nodes, edges, and their attributes, representing the complete waterway network.
+*   `ris-index.gpkg`: A GeoPackage file related to the River Information Services (RIS) index. For more information on this data, see the [RIS Index API documentation](https://eurisportal.eu/ris-index-api-documentation).


### PR DESCRIPTION
Resolves #54

### Changes
- Added `uv` installation and `uv sync` instructions to `README.md`
- Added prerequisite notifications to submodule READMEs and linked back to the root
- Removed duplicated Pipeline Architecture section in `README.md`
- Corrected obsolete EURIS output filenames in `notebooks/euris/README.md` and `fis/graph/README.md` based on actual outputs from `fis.cli graph euris`