### PR TITLE
fix: enforce utf-8 encoding for text outputs

### DIFF
--- a/fis/bridge/cli.py
+++ b/fis/bridge/cli.py
@@ -138,7 +138,7 @@ def schematize(
     result = group_bridge_complexes(data)
 
     output_json = output_dir / "summary.json"
-    with open(output_json, "w") as f:
+    with open(output_json, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2)
     logger.info("Saved summary to %s", output_json)
 

--- a/fis/graph/cli.py
+++ b/fis/graph/cli.py
@@ -157,7 +157,7 @@ def enrich_fis(
         "num_connected_components": nx.number_connected_components(graph),
         "edges_with_cemt": enriched_edges,
     }
-    with open(output_dir / "summary.json", "w") as f:
+    with open(output_dir / "summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
     logger.info("FIS enriched graph exported to %s", output_dir)
@@ -207,7 +207,7 @@ def enrich_euris(
         "num_connected_components": nx.number_connected_components(graph),
         "enrichment": ["sailing_speed"],
     }
-    with open(output_dir / "summary.json", "w") as f:
+    with open(output_dir / "summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
     logger.info("EURIS enriched graph at %s", output_dir)
@@ -358,7 +358,7 @@ def merge(
         "border_connections": len(connections),
         "schema_version": schema_version,
     }
-    with open(output_dir / "summary.json", "w") as f:
+    with open(output_dir / "summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
     # Export border connections for inspection
@@ -432,7 +432,7 @@ def validate(
     report = validator.generate_markdown_report()
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(report)
 
     logger.info("Validation report written to %s", output_file)

--- a/fis/graph/euris.py
+++ b/fis/graph/euris.py
@@ -252,7 +252,7 @@ def export_euris_graph(
         "num_edges": graph.number_of_edges(),
         "num_connected_components": nx.number_connected_components(graph),
     }
-    with open(output_dir / "summary.json", "w") as f:
+    with open(output_dir / "summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
     # Copy ris-index.gpkg

--- a/fis/graph/io.py
+++ b/fis/graph/io.py
@@ -82,7 +82,7 @@ def export_graph(
     }
     summary_path = output_dir / "summary.json"
     logger.info("Exporting summary to %s", summary_path)
-    with open(summary_path, "w") as f:
+    with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
     logger.info("Export complete: %s", output_dir)

--- a/fis/lock/cli.py
+++ b/fis/lock/cli.py
@@ -89,7 +89,7 @@ def schematize(
 
     # Summary JSON (per-lock metadata)
     output_json = output_dir / "summary.json"
-    with open(output_json, "w") as f:
+    with open(output_json, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2)
     logger.info("Saved summary to %s", output_json)
 


### PR DESCRIPTION
This PR adds explicit `encoding='utf-8'` to all `open()` calls used for writing text files (summaries, reports) to ensure compatibility across all platforms, specifically Windows where the default encoding might not be UTF-8.