### PR TITLE
test: skip topological scenarios if data not generated

### DIFF
--- a/tests/test_topological_scenarios.py
+++ b/tests/test_topological_scenarios.py
@@ -1,6 +1,12 @@
+from pathlib import Path
 import geopandas as gpd
 import networkx as nx
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    not Path("output/dropins-schematization/edges.geoparquet").exists(),
+    reason="Required test data not generated in output/dropins-schematization/",
+)
 
 
 def load_graph():


### PR DESCRIPTION
Resolves #75 by gracefully skipping the topological scenario integration tests when the locally generated  artifact is absent, preventing failures in the CI pipeline.