### PR TITLE
Refactor bridge matching and improve bridge passage geometry (#97)

### DIFF
--- a/fis/bridge/graph.py
+++ b/fis/bridge/graph.py
@@ -4,7 +4,7 @@ from shapely.geometry import Point, LineString, mapping
 from pyproj import Geod
 import json
 import pandas as pd
-from fis import utils
+from fis import utils, settings
 
 geod = Geod(ellps="WGS84")
 CRS = "EPSG:4326"
@@ -187,6 +187,20 @@ def build_graph_features(complexes):
 
             op_geom = op_geom_raw
 
+            # Calculate orientation and offset points to give the passage a real length
+            azimuth = 0.0
+            if split_point and merge_point and not split_point.equals(merge_point):
+                azimuth, _, _ = geod.inv(
+                    split_point.x, split_point.y, merge_point.x, merge_point.y
+                )
+
+            # Offset 1m back and 1m forward along the azimuth
+            half_len = settings.BRIDGE_PASSAGE_LENGTH_M / 2.0
+            lon1, lat1, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, -half_len)
+            lon2, lat2, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, half_len)
+            op_start_geom = Point(lon1, lat1)
+            op_end_geom = Point(lon2, lat2)
+
             op_start_node = f"opening_{op_id}_start"
             op_end_node = f"opening_{op_id}_end"
 
@@ -205,7 +219,7 @@ def build_graph_features(complexes):
             features.append(
                 {
                     "type": "Feature",
-                    "geometry": mapping(op_geom),
+                    "geometry": mapping(op_start_geom),
                     "properties": {
                         "id": op_start_node,
                         "feature_type": "node",
@@ -219,7 +233,7 @@ def build_graph_features(complexes):
             features.append(
                 {
                     "type": "Feature",
-                    "geometry": mapping(op_geom),
+                    "geometry": mapping(op_end_geom),
                     "properties": {
                         "id": op_end_node,
                         "feature_type": "node",
@@ -233,8 +247,8 @@ def build_graph_features(complexes):
 
             if split_point:
                 approach_geom = (
-                    LineString([split_point, op_geom])
-                    if not split_point.equals(op_geom)
+                    LineString([split_point, op_start_geom])
+                    if not split_point.equals(op_start_geom)
                     else None
                 )
                 features.append(
@@ -259,7 +273,7 @@ def build_graph_features(complexes):
                     }
                 )
 
-            passage_geom = LineString([op_geom, op_geom])
+            passage_geom = LineString([op_start_geom, op_end_geom])
 
             # Serialize metadata and handle nominal length
             op_attrs = {}
@@ -289,15 +303,15 @@ def build_graph_features(complexes):
                         "section_id": best_sec_id,
                         "source_node": op_start_node,
                         "target_node": op_end_node,
-                        "length_m": 2.0,  # Nominal length for simulation compatibility
+                        "length_m": settings.BRIDGE_PASSAGE_LENGTH_M,  # Nominal length for simulation compatibility
                     },
                 }
             )
 
             if merge_point:
                 exit_geom = (
-                    LineString([op_geom, merge_point])
-                    if not op_geom.equals(merge_point)
+                    LineString([op_end_geom, merge_point])
+                    if not op_end_geom.equals(merge_point)
                     else None
                 )
                 features.append(

--- a/fis/dropins/core.py
+++ b/fis/dropins/core.py
@@ -189,12 +189,12 @@ def _identify_embedded_structures(
 
     openings_rd = openings_gdf.to_crs(settings.PROJECTED_CRS)
     chambers_rd = chambers_gdf.to_crs(settings.PROJECTED_CRS)
-    matches = {}
+
+    all_candidates = []
 
     for _, op_row in openings_rd.iterrows():
         op_id = str(op_row["id"])
         op_name = str(op_row.get("name", op_row.get("Name", ""))).lower()
-        candidates = []
         for _, ch_row in chambers_rd.iterrows():
             ch_id = str(ch_row["id"])
             ch_name = str(ch_row.get("name", ch_row.get("Name", ""))).lower()
@@ -202,13 +202,18 @@ def _identify_embedded_structures(
             if dist > settings.EMBEDDED_STRUCTURE_MAX_DIST_M:
                 continue
             score = _calculate_semantic_spatial_score(op_name, ch_name, dist)
-            candidates.append((score, dist, ch_id, ch_row))
+            if score > 1.0:
+                all_candidates.append((score, dist, op_id, ch_id, ch_row))
 
-        if candidates:
-            candidates.sort(key=lambda x: (-x[0], x[1]))
-            best_score, best_dist, best_ch_id, best_ch_row = candidates[0]
-            if best_score > 1.0:
-                matches[op_id] = {"ch_id": best_ch_id, "ch_row": best_ch_row}
+    all_candidates.sort(key=lambda x: (-x[0], x[1]))
+
+    matches = {}
+    matched_chs = set()
+
+    for score, dist, op_id, ch_id, ch_row in all_candidates:
+        if op_id not in matches and ch_id not in matched_chs:
+            matches[op_id] = {"ch_id": ch_id, "ch_row": ch_row}
+            matched_chs.add(ch_id)
 
     return matches
 
@@ -887,7 +892,7 @@ def _export_graph(
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    G = nx.MultiDiGraph()
+    G = nx.MultiGraph()
     _populate_graph(G, nodes_gdf, edges_gdf)
 
     with open(output_dir / "graph.pickle", "wb") as f:
@@ -922,7 +927,7 @@ def _separate_features(all_features: List[Dict]) -> Tuple[List[Dict], List[Dict]
 
 
 def _populate_graph(
-    G: nx.MultiDiGraph, nodes_gdf: gpd.GeoDataFrame, edges_gdf: gpd.GeoDataFrame
+    G: nx.MultiGraph, nodes_gdf: gpd.GeoDataFrame, edges_gdf: gpd.GeoDataFrame
 ):
     for _, row in nodes_gdf.iterrows():
         node_attr = {k: v for k, v in row.items() if k != "geometry"}

--- a/fis/graph/cli.py
+++ b/fis/graph/cli.py
@@ -427,6 +427,7 @@ def validate(
     validator.check_schema_compliance()
     validator.check_critical_connections()
     validator.check_dropins()
+    validator.check_edge_geometry()
 
     # Generate report
     report = validator.generate_markdown_report()

--- a/fis/graph/templates/validation_report.md.j2
+++ b/fis/graph/templates/validation_report.md.j2
@@ -82,7 +82,32 @@
 - **Bridge Openings Integrated**: {{ "Yes" if dropins.openings_present else "No" }}
 - **Total Spliced Edges**: {{ dropins.total_splices }}
 
-## 6. Suggested Improvements
+## 6. Edge Geometry Consistency
+- **Status**: {% if edge_geometry.status == "PASS" %}✅{% else %}⚠️{% endif %} {{ edge_geometry.status }}
+- **Zero-length Edges**: {{ edge_geometry.zero_length_count }}
+- **Mismatched Lengths (>1m)**: {{ edge_geometry.mismatched_length_count }}
+- **Max Length Mismatch**: {{ "%.2f"|format(edge_geometry.max_mismatch_meters) }} m
+- **Avg Length Mismatch**: {{ "%.2f"|format(edge_geometry.avg_mismatch_meters) }} m
+
+{% if edge_geometry.zero_length_count > 0 %}
+### Zero-length Edge Examples
+| Edge ID | Source Node | Target Node | Actual Len |
+|---------|-------------|-------------|------------|
+{% for e in edge_geometry.zero_length_examples %}
+| {{ e.id }} | {{ e.u }} | {{ e.v }} | {{ "%.4f"|format(e.actual_len) }} |
+{% endfor %}
+{% endif %}
+
+{% if edge_geometry.mismatched_length_count > 0 %}
+### Mismatched Length Examples (Top 10)
+| Edge ID | length_m | geometry length | Difference |
+|---------|----------|-----------------|------------|
+{% for e in edge_geometry.mismatched_length_examples %}
+| {{ e.id }} | {{ "%.2f"|format(e.length_m) }} | {{ "%.2f"|format(e.actual_len) }} | {{ "%.2f"|format(e.diff) }} |
+{% endfor %}
+{% endif %}
+
+## 7. Suggested Improvements
 - **Attribute Cleanup**: Investigate attributes with high missing/null counts (>50%) and determine if they are required or can be dropped.
 - **Graph Connectivity**: There are multiple disjoint subgraphs. Investigate whether the top 2-10 subgraphs are legitimately disconnected waterways or missing logical connections.
 - **Legacy Attributes**: If non-standard legacy attributes are flagged, ensure they are added to `schema.toml` `attributes.edges` or `attributes.nodes` to map to canonical names.

--- a/fis/graph/validation.py
+++ b/fis/graph/validation.py
@@ -29,7 +29,87 @@ class GraphValidator:
             "schema_compliance": {},
             "critical_connections": {},
             "dropins": {},
+            "edge_geometry": {},
         }
+
+    def check_edge_geometry(self) -> Dict[str, Any]:
+        """Check edge geometry consistency (length_m vs actual length, non-zero length)."""
+        logger.info("Checking edge geometry consistency...")
+        from pyproj import Geod
+        from shapely import wkt
+        from shapely.geometry import LineString
+
+        geod = Geod(ellps="WGS84")
+
+        zero_length_edges = []
+        mismatched_length_edges = []
+        total_mismatch_error = 0.0
+        max_mismatch_error = 0.0
+
+        for u, v, d in self.graph.edges(data=True):
+            geom = d.get("geometry")
+            if not geom:
+                continue
+
+            if isinstance(geom, str):
+                line = wkt.loads(geom)
+            else:
+                # Assuming it's already a shapely object or mapping
+                from shapely.geometry import shape
+
+                line = shape(geom)
+
+            if not isinstance(line, LineString):
+                continue
+
+            actual_len = geod.geometry_length(line)
+            length_m = d.get("length_m")
+
+            if actual_len < 0.001:  # 1mm threshold for "zero"
+                zero_length_edges.append(
+                    {
+                        "id": d.get("id", f"{u}->{v}"),
+                        "u": u,
+                        "v": v,
+                        "actual_len": actual_len,
+                    }
+                )
+
+            if length_m is not None:
+                diff = abs(actual_len - length_m)
+                if diff > 1.0:  # 1 meter threshold for mismatch
+                    mismatched_length_edges.append(
+                        {
+                            "id": d.get("id", f"{u}->{v}"),
+                            "u": u,
+                            "v": v,
+                            "length_m": length_m,
+                            "actual_len": actual_len,
+                            "diff": diff,
+                        }
+                    )
+                total_mismatch_error += diff
+                if diff > max_mismatch_error:
+                    max_mismatch_error = diff
+
+        edge_geometry = {
+            "zero_length_count": len(zero_length_edges),
+            "zero_length_examples": zero_length_edges[:10],
+            "mismatched_length_count": len(mismatched_length_edges),
+            "mismatched_length_examples": sorted(
+                mismatched_length_edges, key=lambda x: x["diff"], reverse=True
+            )[:10],
+            "max_mismatch_meters": max_mismatch_error,
+            "avg_mismatch_meters": total_mismatch_error / self.graph.number_of_edges()
+            if self.graph.number_of_edges() > 0
+            else 0.0,
+            "status": "PASS"
+            if not zero_length_edges
+            and len(mismatched_length_edges) < (self.graph.number_of_edges() * 0.05)
+            else "WARNING",
+        }
+        self.results["edge_geometry"] = edge_geometry
+        return edge_geometry
 
     def check_statistics(self) -> Dict[str, Any]:
         """Calculate graph statistics."""
@@ -295,6 +375,7 @@ class GraphValidator:
         schema = self.results["schema_compliance"]
         critical = self.results["critical_connections"]
         dropins = self.results.get("dropins", {})
+        edge_geometry = self.results.get("edge_geometry", {})
 
         # Calculate sources for table
         sources = set(
@@ -313,5 +394,6 @@ class GraphValidator:
             schema=schema,
             critical=critical,
             dropins=dropins,
+            edge_geometry=edge_geometry,
             sources=list(sources),
         )

--- a/fis/settings.py
+++ b/fis/settings.py
@@ -115,6 +115,9 @@ DETAILED_LOCK_SPLICING_BUFFER_M = 50.0
 # Fixed cut distance for bridge structures.
 BRIDGE_SPLICING_BUFFER_M = 10.0
 
+# Nominal length (meters) assigned to bridge passage edges for simulation compatibility.
+BRIDGE_PASSAGE_LENGTH_M = 2.0
+
 # Minimal buffer for locks in 'simplified' mode.
 # Prevents large lock complexes from "swallowing" nearby bridges or junctions.
 SIMPLIFIED_LOCK_SPLICING_BUFFER_M = 10.0

--- a/tests/test_embedded_matching.py
+++ b/tests/test_embedded_matching.py
@@ -1,0 +1,138 @@
+import geopandas as gpd
+from shapely.geometry import Point
+from unittest.mock import patch
+from fis.dropins.core import _identify_embedded_structures
+
+
+@patch("fis.lock.graph.build_chambers_gdf")
+@patch("fis.bridge.graph.build_openings_gdf")
+def test_identify_embedded_structures_one_to_one(
+    mock_build_openings, mock_build_chambers
+):
+    """
+    Ensure that one chamber is matched to at most one bridge opening,
+    even if multiple openings are within range.
+    """
+    # Create two openings close to a single chamber
+    # Chamber at (0, 0)
+    chambers_gdf = gpd.GeoDataFrame(
+        [{"id": "ch1", "name": "Main Lock", "geometry": Point(0, 0)}], crs="EPSG:28992"
+    )  # Using projected CRS for distance
+
+    # Opening 1 at (10, 0) - Score high
+    # Opening 2 at (20, 0) - Score also high
+    openings_gdf = gpd.GeoDataFrame(
+        [
+            {"id": "op1", "name": "Main Bridge", "geometry": Point(10, 0)},
+            {"id": "op2", "name": "Main Bridge", "geometry": Point(20, 0)},
+        ],
+        crs="EPSG:28992",
+    )
+
+    mock_build_chambers.return_value = chambers_gdf
+    mock_build_openings.return_value = openings_gdf
+
+    # We need to mock the CRS transformation or just use the same CRS
+    # _identify_embedded_structures uses settings.PROJECTED_CRS
+    from fis import settings
+
+    chambers_gdf = chambers_gdf.to_crs(settings.PROJECTED_CRS)
+    openings_gdf = openings_gdf.to_crs(settings.PROJECTED_CRS)
+    mock_build_chambers.return_value = chambers_gdf
+    mock_build_openings.return_value = openings_gdf
+
+    matches = _identify_embedded_structures([], [])
+
+    # Should only have one match for ch1
+    # Since op1 is closer, it should win
+    assert len(matches) == 1
+    assert "op1" in matches
+    assert matches["op1"]["ch_id"] == "ch1"
+    assert "op2" not in matches
+
+
+@patch("fis.lock.graph.build_chambers_gdf")
+@patch("fis.bridge.graph.build_openings_gdf")
+def test_identify_embedded_structures_global_greedy(
+    mock_build_openings, mock_build_chambers
+):
+    """
+    Test that the global greedy matching picks the best overall matches.
+    """
+    # op1 is close to ch1 and ch2.
+    # op2 is close to ch1.
+
+    # ch1 at (0,0), ch2 at (100, 0)
+    chambers_gdf = gpd.GeoDataFrame(
+        [
+            {"id": "ch1", "name": "Lock A", "geometry": Point(0, 0)},
+            {"id": "ch2", "name": "Lock B", "geometry": Point(100, 0)},
+        ],
+        crs="EPSG:28992",
+    )
+
+    # op1 at (10, 0) -> Very close to ch1, reasonably close to ch2
+    # op2 at (5, 0) -> Even closer to ch1
+    openings_gdf = gpd.GeoDataFrame(
+        [
+            {"id": "op1", "name": "Bridge 1", "geometry": Point(10, 0)},
+            {"id": "op2", "name": "Bridge 2", "geometry": Point(5, 0)},
+        ],
+        crs="EPSG:28992",
+    )
+
+    from fis import settings
+
+    mock_build_chambers.return_value = chambers_gdf.to_crs(settings.PROJECTED_CRS)
+    mock_build_openings.return_value = openings_gdf.to_crs(settings.PROJECTED_CRS)
+
+    matches = _identify_embedded_structures([], [])
+
+    # op2 is closest to ch1 (dist 5). op1 is then forced to match with ch2 (dist 90)
+    # OR if op1 matched ch1 (dist 10), op2 would have nothing.
+    # Global greedy: (op2, ch1, dist 5) is best match. Then (op1, ch2, dist 90) is next best.
+
+    assert len(matches) == 2
+    assert matches["op2"]["ch_id"] == "ch1"
+    assert matches["op1"]["ch_id"] == "ch2"
+
+
+@patch("fis.lock.graph.build_chambers_gdf")
+@patch("fis.bridge.graph.build_openings_gdf")
+def test_identify_embedded_structures_score_wins(
+    mock_build_openings, mock_build_chambers
+):
+    """
+    Test that semantic score wins over pure spatial distance.
+    """
+    # ch_west at (0,0), ch_east at (100, 0)
+    chambers_gdf = gpd.GeoDataFrame(
+        [
+            {"id": "ch_west", "name": "Sluis west", "geometry": Point(0, 0)},
+            {"id": "ch_east", "name": "Sluis oost", "geometry": Point(100, 0)},
+        ],
+        crs="EPSG:28992",
+    )
+
+    # op_east is at (10, 0)
+    # Distance to ch_west is 10. Distance to ch_east is 90.
+    # But op_east has 'oost' in name, so it should match ch_east despite distance.
+    openings_gdf = gpd.GeoDataFrame(
+        [{"id": "op_east", "name": "Brug oost", "geometry": Point(10, 0)}],
+        crs="EPSG:28992",
+    )
+
+    from fis import settings
+
+    mock_build_chambers.return_value = chambers_gdf.to_crs(settings.PROJECTED_CRS)
+    mock_build_openings.return_value = openings_gdf.to_crs(settings.PROJECTED_CRS)
+
+    matches = _identify_embedded_structures([], [])
+
+    # 'oost' match gives +10 score.
+    # Dist 10 to West gives score 5 - 10/100 = 4.9. Total 4.9.
+    # Dist 90 to East gives score 5 - 90/100 = 4.1. Total 10 + 4.1 = 14.1.
+    # So ch_east should win.
+
+    assert len(matches) == 1
+    assert matches["op_east"]["ch_id"] == "ch_east"


### PR DESCRIPTION
Refactor bridge-to-chamber matching logic and improve bridge passage geometry to ensure a clean, accurate network topology, particularly in dense areas like Amsterdam.

Key changes:
- Enforce a strict 1-to-1 relationship between bridge openings and lock chambers using a global greedy matching algorithm.
- Replace zero-length bridge passage points with a 2-meter physical `LineString` oriented along the fairway.
- Add edge geometry consistency checks to the validation report.
- Switch drop-ins graph export to an undirected `MultiGraph`.
- Add a regression test for embedded structure matching.

Fixes #97