### PR TITLE
fix(lock): assign correct section ID based on geometry for chamber segments (Issue #88)

### DIFF
--- a/fis/lock/graph.py
+++ b/fis/lock/graph.py
@@ -472,6 +472,50 @@ def _process_chambers(c, split_node_id, merge_node_id, split_point, merge_point)
     return features
 
 
+def _find_best_section_id(line, sections):
+    """Find the section ID with the most overlap with the given line."""
+    if not sections:
+        return None
+
+    best_sid = None
+    max_overlap = -1.0
+
+    # 1. Try intersection length
+    for s in sections:
+        s_geom_wkt = s.get("geometry")
+        if not s_geom_wkt:
+            continue
+        s_geom = wkt.loads(s_geom_wkt) if isinstance(s_geom_wkt, str) else s_geom_wkt
+
+        if s_geom and line.intersects(s_geom):
+            overlap = line.intersection(s_geom).length
+            if overlap > max_overlap:
+                max_overlap = overlap
+                best_sid = utils.stringify_id(s.get("id"))
+
+    # 2. Fallback to nearest if no intersection
+    if best_sid is None:
+        min_dist = float("inf")
+        for s in sections:
+            s_geom_wkt = s.get("geometry")
+            if not s_geom_wkt:
+                continue
+            s_geom = (
+                wkt.loads(s_geom_wkt) if isinstance(s_geom_wkt, str) else s_geom_wkt
+            )
+            if s_geom:
+                dist = line.distance(s_geom)
+                if dist < min_dist:
+                    min_dist = dist
+                    best_sid = utils.stringify_id(s.get("id"))
+
+    # 3. Final fallback to the first section
+    if best_sid is None and sections:
+        best_sid = utils.stringify_id(sections[0].get("id"))
+
+    return best_sid
+
+
 def _build_chamber_route_features(
     c,
     lock_id,
@@ -541,9 +585,9 @@ def _build_chamber_route_features(
                 "chamber_id": chamber_id,
                 "fairway_id": fairway_id,
                 "name": c.get("fairway_name"),
-                "section_id": utils.stringify_id(c.get("sections", [{}])[0].get("id"))
-                if c.get("sections")
-                else None,
+                "section_id": _find_best_section_id(
+                    approach_line, c.get("sections", [])
+                ),
                 "source_node": split_node_id,
                 "target_node": chamber_node_start_id,
                 "length_m": geod.geometry_length(approach_line),
@@ -567,9 +611,9 @@ def _build_chamber_route_features(
                 "chamber_id": chamber_id,
                 "fairway_id": fairway_id,
                 "name": c.get("fairway_name"),
-                "section_id": utils.stringify_id(c.get("sections", [{}])[0].get("id"))
-                if c.get("sections")
-                else None,
+                "section_id": _find_best_section_id(
+                    chamber_line, c.get("sections", [])
+                ),
                 "dim_length": chamber.get("dim_length"),
                 "dim_width": chamber.get("dim_width"),
                 "source_node": chamber_node_start_id,
@@ -595,9 +639,7 @@ def _build_chamber_route_features(
                 "chamber_id": chamber_id,
                 "fairway_id": fairway_id,
                 "name": c.get("fairway_name"),
-                "section_id": utils.stringify_id(c.get("sections", [{}])[0].get("id"))
-                if c.get("sections")
-                else None,
+                "section_id": _find_best_section_id(exit_line, c.get("sections", [])),
                 "source_node": chamber_node_end_id,
                 "target_node": merge_node_id,
                 "length_m": geod.geometry_length(exit_line),

--- a/tests/test_graph_chambers.py
+++ b/tests/test_graph_chambers.py
@@ -82,3 +82,91 @@ def test_build_chamber_route_features():
     assert exit_seg["properties"]["source_node"] == chamber_node_end_id
     assert exit_seg["properties"]["target_node"] == merge_node_id
     assert exit_seg["properties"]["length_m"] > 0
+
+
+def test_lock_overlapping_multiple_sections():
+    """
+    Test that when a lock overlaps two fairway sections meeting in the middle,
+    the approach and exit segments get the correct section IDs based on geometry,
+    rather than just the first section in the list.
+    """
+    from shapely.geometry import LineString, Polygon
+    from fis.lock.graph import build_graph_features
+
+    # Construct a lock complex spanning from x=0 to x=100
+    # Two sections:
+    #   "21084" from x=-50 to x=50 (intersecting the start/approach)
+    #   "7849" from x=50 to x=150 (intersecting the end/exit)
+    # The lock chamber goes from x=20 to x=80
+
+    c = {
+        "id": "51064",
+        "geometry": Polygon([(0, -10), (100, -10), (100, 10), (0, 10), (0, -10)]).wkt,
+        "geometry_before_wkt": LineString(
+            [(-50, 0), (0, 0)]
+        ).wkt,  # split point at (0, 0)
+        "geometry_after_wkt": LineString(
+            [(100, 0), (150, 0)]
+        ).wkt,  # merge point at (100, 0)
+        "fairway_id": "fw1",
+        "sections": [
+            {
+                "id": "21084",
+                "geometry": LineString([(-50, 0), (50, 0)]).wkt,
+                "relation": "overlap",
+            },
+            {
+                "id": "7849",
+                "geometry": LineString([(50, 0), (150, 0)]).wkt,
+                "relation": "overlap",
+            },
+        ],
+        "locks": [
+            {
+                "id": "lock1",
+                "chambers": [
+                    {
+                        "id": "24969",
+                        "geometry": Polygon(
+                            [(20, -5), (80, -5), (80, 5), (20, 5), (20, -5)]
+                        ).wkt,
+                        "dim_length": 60,
+                        "dim_width": 10,
+                    }
+                ],
+            }
+        ],
+    }
+
+    # Generate graph features
+    features = build_graph_features([c])
+
+    # Extract the approach, route and exit segments
+    approach = next(
+        f
+        for f in features
+        if f.get("properties", {}).get("segment_type") == "chamber_approach"
+    )
+    route = next(
+        f
+        for f in features
+        if f.get("properties", {}).get("segment_type") == "chamber_route"
+    )
+    exit_seg = next(
+        f
+        for f in features
+        if f.get("properties", {}).get("segment_type") == "chamber_exit"
+    )
+
+    # Verify the approach segment gets section 21084
+    assert approach["properties"]["section_id"] == "21084", (
+        "Approach segment should match the start section"
+    )
+
+    # Verify the exit segment gets section 7849
+    assert exit_seg["properties"]["section_id"] == "7849", (
+        "Exit segment should match the end section"
+    )
+
+    # Route segment should also be assigned to one of the overlapping sections
+    assert route["properties"]["section_id"] in ("21084", "7849")


### PR DESCRIPTION
Resolves #88.

Internal lock chamber segments (approach, route, exit) were being assigned the `section_id` of the first overlapping section in the list, regardless of where they actually lay geometrically. This PR introduces a dynamic assignment based on intersection length and proximity.

Key changes:
- Added `_find_best_section_id` in `fis/lock/graph.py`.
- Updated segment generation to use this helper.
- Added a regression test in `tests/test_graph_chambers.py`.