### PR TITLE
Fix BIVAS download: use gdown in Makefile (#125)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ crawl: crawl-fis crawl-euris crawl-disk
 reference/Bivas.5.10.1.sqlite:
 	mkdir -p reference
 	@echo "Downloading BIVAS database from Google Drive..."
-	curl -L -c reference/cookies.txt 'https://docs.google.com/uc?export=download&id=1s2QXcWnpUkALgF17zBKKv3j6ZVdKUXIP' | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1/p' > reference/confirm.txt
-	curl -L -b reference/cookies.txt 'https://docs.google.com/uc?export=download&confirm='$$(cat reference/confirm.txt)'&id=1s2QXcWnpUkALgF17zBKKv3j6ZVdKUXIP' -o reference/BIVAS_v5.10.1.zip
-	rm reference/cookies.txt reference/confirm.txt
+	uv run gdown 1s2QXcWnpUkALgF17zBKKv3j6ZVdKUXIP -O reference/BIVAS_v5.10.1.zip
 	unzip -o reference/BIVAS_v5.10.1.zip -d reference/
 	mv reference/Bivas.db reference/Bivas.5.10.1.sqlite
 	@echo "BIVAS database ready at reference/Bivas.5.10.1.sqlite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "click>=8.3.0",
     "dask>=2025.5.1",
+    "gdown>=5.2.1",
     "geopandas>=1.1.0",
     "geoviews>=1.14.0",
     "holoviews>=1.20.2",

--- a/uv.lock
+++ b/uv.lock
@@ -591,6 +591,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "dask" },
+    { name = "gdown" },
     { name = "geopandas" },
     { name = "geoviews" },
     { name = "holoviews" },
@@ -616,6 +617,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
     { name = "dask", specifier = ">=2025.5.1" },
+    { name = "gdown", specifier = ">=5.2.1" },
     { name = "geopandas", specifier = ">=1.1.0" },
     { name = "geoviews", specifier = ">=1.14.0" },
     { name = "holoviews", specifier = ">=1.20.2" },
@@ -686,6 +688,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "gdown"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/cf/919a9fa16faf8e4572a24d941353edaf4d54e3ddcd048e6c1aeb8c7a9903/gdown-5.2.1.tar.gz", hash = "sha256:247c2ad1f579db5b66b54c04e6a871995fc8fd7021708b950b8ba7b32cf90323", size = 284743, upload-time = "2026-01-11T09:34:01.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/21/35dd0a0b7428bd67b12b358d7b4277f693493a3839b071d540a4c8357b78/gdown-5.2.1-py3-none-any.whl", hash = "sha256:391f0480d495fb87644d1a1ee3ddfeb2144e1de31408fbc74f7e3b3ba927052b", size = 18241, upload-time = "2026-01-11T09:34:02.637Z" },
 ]
 
 [[package]]
@@ -2170,6 +2187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2348,6 +2374,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Fix BIVAS Download in CI

The previous PR #127 was merged before the `curl` fix was pushed to the branch, and even that fix was somewhat brittle due to Google Drive's evolving confirmation page structure.

### Changes:
- Added `gdown` to project dependencies for robust Google Drive downloads.
- Updated `Makefile` to use `uv run gdown` for downloading the BIVAS database.

This ensures the BIVAS database is correctly downloaded even when Google Drive presents a virus scan warning page.