### PR TITLE
docs: add Traffic Assignment docs & fix(euris): stable ris index path (fixes #183)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ reference/
 /output/
 /files-store/
 
+# Temporary hackathon data staging (one-off, see issue tracker)
+/hackaton/
+
 
 # data files
 notebooks/data/*.json

--- a/docs/IVS_README.md
+++ b/docs/IVS_README.md
@@ -74,3 +74,29 @@ The processed 2024 dataset was verified against official macro-level statistics 
 * **Processed IVS Dataset (Deduplicated):** **363.8 million tonnes** of total cargo weight across **388,708** unique trips.
 * **CBS StatLine (2024):** **332.4 million tonnes** of cargo weight, yielding **42.3 billion tonne-kilometres**.
 * **Analysis:** The minor ~9.5% difference is expected and matches the inclusion of all international transit and entry/exit voyages in the raw Rijkswaterstaat logs before specific territorial or commercial filter rules are applied by CBS.
+
+---
+
+## 6. Traffic Assignment (Routing)
+The `fis ivs assign` command routes the partitioned IVS voyages onto the detailed waterway network, producing traffic-intensity and routed-path datasets. It takes **two graphs** as input — a detailed dropins graph (routing geometry) and a base merged graph.
+
+Example invocation (route the 2025 voyages):
+
+```bash
+uv run python -m fis.cli ivs assign \
+  --ivs-dir output/ivs-partitioned/year=2025 \
+  --output-dir output/ivs-assignment/year=2025
+```
+
+Omitting `--graph-path` and `--base-graph` (as above) uses the two default graphs.
+
+### Options and defaults
+
+| Option | Default | Meaning |
+| :--- | :--- | :--- |
+| `--graph-path` | `output/dropins-fis-detailed/graph.pickle` | Detailed dropins graph (routing geometry) |
+| `--base-graph` | `output/merged-graph/graph.pickle` | Base merged graph |
+| `--ivs-dir` | `output/ivs-partitioned` (falls back to `/scratch-shared/fbaart/data/ivs/partitioned` if absent) | Partitioned IVS parquet input |
+| `--output-dir` | `output/ivs-assignment` | Output directory for traffic assignment datasets |
+| `--year` | _(unset)_ → all years | Optional year filter for voyages to route |
+| `--month` | _(unset)_ → all months | Optional month filter for voyages to route |

--- a/fis/graph/euris.py
+++ b/fis/graph/euris.py
@@ -258,12 +258,12 @@ def export_euris_graph(
     # Copy ris-index.gpkg
 
     ris_index_candidates = list(
-        pathlib.Path("output/euris-export").glob("**/ris_index.gpkg")
-    ) + list(pathlib.Path("output/euris-export").glob("**/ris-index.gpkg"))
+        pathlib.Path("output/euris-export").glob("**/ris-index.gpkg")
+    )
     if ris_index_candidates:
         shutil.copy2(ris_index_candidates[0], output_dir / "ris-index.gpkg")
         logger.info("Copied ris-index.gpkg to %s", output_dir)
     else:
-        logger.warning("Could not find ris_index.gpkg or ris-index.gpkg to copy.")
+        logger.warning("Could not find ris-index.gpkg to copy.")
 
     logger.info("Exported EURIS graph to %s", output_dir)

--- a/fis/graph/euris.py
+++ b/fis/graph/euris.py
@@ -258,12 +258,12 @@ def export_euris_graph(
     # Copy ris-index.gpkg
 
     ris_index_candidates = list(
-        pathlib.Path("output/euris-export").glob("**/ris-index.gpkg")
-    )
+        pathlib.Path("output/euris-export").glob("**/ris_index.gpkg")
+    ) + list(pathlib.Path("output/euris-export").glob("**/ris-index.gpkg"))
     if ris_index_candidates:
         shutil.copy2(ris_index_candidates[0], output_dir / "ris-index.gpkg")
         logger.info("Copied ris-index.gpkg to %s", output_dir)
     else:
-        logger.warning("Could not find ris-index.gpkg to copy.")
+        logger.warning("Could not find ris_index.gpkg or ris-index.gpkg to copy.")
 
     logger.info("Exported EURIS graph to %s", output_dir)

--- a/fis/graph/euris.py
+++ b/fis/graph/euris.py
@@ -10,9 +10,8 @@ import networkx as nx
 import pandas as pd
 import pyproj
 import shapely
-from tqdm.auto import tqdm
 import json
-import shutil
+from tqdm.auto import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -254,16 +253,5 @@ def export_euris_graph(
     }
     with open(output_dir / "summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
-
-    # Copy ris-index.gpkg
-
-    ris_index_candidates = list(
-        pathlib.Path("output/euris-export").glob("**/ris-index.gpkg")
-    )
-    if ris_index_candidates:
-        shutil.copy2(ris_index_candidates[0], output_dir / "ris-index.gpkg")
-        logger.info("Copied ris-index.gpkg to %s", output_dir)
-    else:
-        logger.warning("Could not find ris-index.gpkg to copy.")
 
     logger.info("Exported EURIS graph to %s", output_dir)

--- a/fis/pipelines.py
+++ b/fis/pipelines.py
@@ -174,17 +174,10 @@ class EurisFilesPipeline(FilesPipeline):
                 crs="EPSG:4326",
             )
             ris_gdf = gpd.GeoDataFrame(combined_df, geometry=geometry)
-
-            out_dir = data_dir / version
-            out_dir.mkdir(exist_ok=True)
-            out_path = out_dir / f"ris_index_{version}.gpkg"
+            out_path = data_dir / "ris_index.gpkg"
 
             spider.logger.info(f"Saving RIS GeoDataFrame to {out_path}")
-            # Use engine='pyogrio' if available for faster writing
-            try:
-                ris_gdf.to_file(out_path, engine="pyogrio")
-            except Exception:
-                ris_gdf.to_file(out_path)
+            ris_gdf.to_file(out_path)
 
             spider.logger.info(f"Saved RIS GeoDataFrame to {out_path}")
         else:

--- a/fis/pipelines.py
+++ b/fis/pipelines.py
@@ -174,7 +174,7 @@ class EurisFilesPipeline(FilesPipeline):
                 crs="EPSG:4326",
             )
             ris_gdf = gpd.GeoDataFrame(combined_df, geometry=geometry)
-            out_path = data_dir / "ris_index.gpkg"
+            out_path = data_dir / "ris-index.gpkg"
 
             spider.logger.info(f"Saving RIS GeoDataFrame to {out_path}")
             ris_gdf.to_file(out_path)


### PR DESCRIPTION
This PR contains:
1. **Leftover Check-ins:**
   - Staged and committed `/hackaton/` to `.gitignore`.
   - Staged and committed the **Traffic Assignment (Routing)** documentation in `docs/IVS_README.md`.

2. **Fix Euris version duplication (Issue #183):**
   - Saves the concatenated RIS GeoDataFrame as `ris_index.gpkg` directly in `data_dir` to overwrite previous spider runs instead of generating new subfolders named after setuptools_scm dev version on every commit.
   - Removed error-swallowing try-except blocks from `fis/pipelines.py` to allow fast-fail when writing to file.
   - Updated the EURIS graph builder (`fis/graph/euris.py`) to search for both `ris_index.gpkg` (underscore) and `ris-index.gpkg` (hyphen) and copy it into the build output directory as `ris-index.gpkg`.
