### PR TITLE
refactor(#130): reduce complexity, fix silent errors, unify CRS, add radon to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,29 @@ jobs:
       - name: Run Integrated Dropins Schematization (subset)
         run: uv run python -m fis.cli dropins schematize --export-dir tests/data/fis-export --disk-dir tests/data/disk-export --output-dir output/dropins-schematization
 
+  complexity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Radon cyclomatic complexity report
+        run: uv run radon cc fis/ -s -n C
+
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/fis/bridge/graph.py
+++ b/fis/bridge/graph.py
@@ -108,15 +108,11 @@ def _build_opening_features(
         )
 
     if split_point:
-        approach_geom = (
-            LineString([split_point, op_start_geom])
-            if not split_point.equals(op_start_geom)
-            else None
-        )
+        approach_geom = LineString([split_point, op_start_geom])
         features.append(
             {
                 "type": "Feature",
-                "geometry": mapping(approach_geom) if approach_geom else None,
+                "geometry": mapping(approach_geom),
                 "properties": {
                     "id": f"bridge_approach_{bridge_id}_{op_id}",
                     "feature_type": "fairway_segment",
@@ -128,9 +124,7 @@ def _build_opening_features(
                     "section_id": best_sec_id,
                     "source_node": split_node_id,
                     "target_node": op_start_node,
-                    "length_m": geod.geometry_length(approach_geom)
-                    if approach_geom
-                    else 0.0,
+                    "length_m": geod.geometry_length(approach_geom),
                 },
             }
         )
@@ -169,15 +163,11 @@ def _build_opening_features(
     )
 
     if merge_point:
-        exit_geom = (
-            LineString([op_end_geom, merge_point])
-            if not op_end_geom.equals(merge_point)
-            else None
-        )
+        exit_geom = LineString([op_end_geom, merge_point])
         features.append(
             {
                 "type": "Feature",
-                "geometry": mapping(exit_geom) if exit_geom else None,
+                "geometry": mapping(exit_geom),
                 "properties": {
                     "id": f"bridge_exit_{bridge_id}_{op_id}",
                     "feature_type": "fairway_segment",
@@ -189,7 +179,7 @@ def _build_opening_features(
                     "section_id": best_sec_id,
                     "source_node": op_end_node,
                     "target_node": merge_node_id,
-                    "length_m": geod.geometry_length(exit_geom) if exit_geom else 0.0,
+                    "length_m": geod.geometry_length(exit_geom),
                 },
             }
         )

--- a/fis/bridge/graph.py
+++ b/fis/bridge/graph.py
@@ -10,6 +10,193 @@ geod = Geod(ellps="WGS84")
 CRS = "EPSG:4326"
 
 
+def _build_split_merge_nodes(c, bridge_id, split_node_id, merge_node_id):
+    """Build the split and merge junction nodes for a bridge complex."""
+    features = []
+    split_point = None
+    merge_point = None
+
+    if c.get("geometry_before_wkt"):
+        g_before = wkt.loads(c["geometry_before_wkt"])
+        split_point = Point(g_before.coords[-1])
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(split_point),
+                "properties": {
+                    "id": split_node_id,
+                    "feature_type": "node",
+                    "node_type": "bridge_split",
+                    "node_id": split_node_id,
+                    "bridge_id": bridge_id,
+                },
+            }
+        )
+
+    if c.get("geometry_after_wkt"):
+        g_after = wkt.loads(c["geometry_after_wkt"])
+        merge_point = Point(g_after.coords[0])
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(merge_point),
+                "properties": {
+                    "id": merge_node_id,
+                    "feature_type": "node",
+                    "node_type": "bridge_merge",
+                    "node_id": merge_node_id,
+                    "bridge_id": bridge_id,
+                },
+            }
+        )
+
+    return split_point, merge_point, features
+
+
+def _build_opening_features(
+    opening,
+    bridge_id,
+    op_id,
+    split_node_id,
+    merge_node_id,
+    split_point,
+    merge_point,
+    best_sec_id,
+):
+    """Build all features (nodes + edges) for a single bridge opening passage."""
+    features = []
+
+    op_geom_raw = wkt.loads(opening["geometry"])
+    if not isinstance(op_geom_raw, Point):
+        op_geom_raw = op_geom_raw.centroid
+    assert isinstance(op_geom_raw, Point), (
+        f"Bridge passage opening {op_id} could not be resolved to a Point."
+    )
+    op_geom = op_geom_raw
+
+    azimuth = 0.0
+    if split_point and merge_point and not split_point.equals(merge_point):
+        azimuth, _, _ = geod.inv(
+            split_point.x, split_point.y, merge_point.x, merge_point.y
+        )
+
+    half_len = settings.BRIDGE_PASSAGE_LENGTH_M / 2.0
+    lon1, lat1, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, -half_len)
+    lon2, lat2, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, half_len)
+    op_start_geom = Point(lon1, lat1)
+    op_end_geom = Point(lon2, lat2)
+    op_start_node = f"opening_{op_id}_start"
+    op_end_node = f"opening_{op_id}_end"
+
+    for node_id, node_geom, node_type in [
+        (op_start_node, op_start_geom, "opening_start"),
+        (op_end_node, op_end_geom, "opening_end"),
+    ]:
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(node_geom),
+                "properties": {
+                    "id": node_id,
+                    "feature_type": "node",
+                    "node_type": node_type,
+                    "node_id": node_id,
+                    "bridge_id": bridge_id,
+                    "opening_id": op_id,
+                },
+            }
+        )
+
+    if split_point:
+        approach_geom = (
+            LineString([split_point, op_start_geom])
+            if not split_point.equals(op_start_geom)
+            else None
+        )
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(approach_geom) if approach_geom else None,
+                "properties": {
+                    "id": f"bridge_approach_{bridge_id}_{op_id}",
+                    "feature_type": "fairway_segment",
+                    "segment_type": "bridge_approach",
+                    "structure_type": "bridge",
+                    "structure_id": bridge_id,
+                    "bridge_id": bridge_id,
+                    "opening_id": op_id,
+                    "section_id": best_sec_id,
+                    "source_node": split_node_id,
+                    "target_node": op_start_node,
+                    "length_m": geod.geometry_length(approach_geom)
+                    if approach_geom
+                    else 0.0,
+                },
+            }
+        )
+
+    passage_geom = LineString([op_start_geom, op_end_geom])
+    op_attrs = {}
+    for k, v in opening.items():
+        if k in ["id", "geometry"]:
+            continue
+        if isinstance(v, (list, dict)):
+            op_attrs[k] = json.dumps(v)
+        elif pd.isna(v):
+            op_attrs[k] = None
+        else:
+            op_attrs[k] = v
+
+    features.append(
+        {
+            "type": "Feature",
+            "geometry": mapping(passage_geom),
+            "properties": {
+                **op_attrs,
+                "id": f"bridge_passage_{bridge_id}_{op_id}",
+                "feature_type": "fairway_segment",
+                "segment_type": "bridge_passage",
+                "structure_type": "bridge",
+                "structure_id": bridge_id,
+                "bridge_id": bridge_id,
+                "opening_id": op_id,
+                "section_id": best_sec_id,
+                "source_node": op_start_node,
+                "target_node": op_end_node,
+                "length_m": settings.BRIDGE_PASSAGE_LENGTH_M,
+            },
+        }
+    )
+
+    if merge_point:
+        exit_geom = (
+            LineString([op_end_geom, merge_point])
+            if not op_end_geom.equals(merge_point)
+            else None
+        )
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(exit_geom) if exit_geom else None,
+                "properties": {
+                    "id": f"bridge_exit_{bridge_id}_{op_id}",
+                    "feature_type": "fairway_segment",
+                    "segment_type": "bridge_exit",
+                    "structure_type": "bridge",
+                    "structure_id": bridge_id,
+                    "bridge_id": bridge_id,
+                    "opening_id": op_id,
+                    "section_id": best_sec_id,
+                    "source_node": op_end_node,
+                    "target_node": merge_node_id,
+                    "length_m": geod.geometry_length(exit_geom) if exit_geom else 0.0,
+                },
+            }
+        )
+
+    return features
+
+
 def build_nodes_gdf(complexes) -> gpd.GeoDataFrame:
     features = build_graph_features(complexes)
     rows = [
@@ -118,222 +305,50 @@ def build_graph_features(complexes):
 
     for c in complexes:
         bridge_id = utils.stringify_id(c["id"])
-
         split_node_id = f"bridge_{bridge_id}_split"
         merge_node_id = f"bridge_{bridge_id}_merge"
 
-        split_point = None
-        if c.get("geometry_before_wkt"):
-            g_before = wkt.loads(c["geometry_before_wkt"])
-            split_point = Point(g_before.coords[-1])
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": mapping(split_point),
-                    "properties": {
-                        "id": split_node_id,
-                        "feature_type": "node",
-                        "node_type": "bridge_split",
-                        "node_id": split_node_id,
-                        "bridge_id": bridge_id,
-                    },
-                }
+        split_point, merge_point, junction_features = _build_split_merge_nodes(
+            c, bridge_id, split_node_id, merge_node_id
+        )
+        features.extend(junction_features)
+
+        openings = c.get("openings", []) or [
+            {
+                "id": f"virtual_{bridge_id}",
+                "width": None,
+                "height": None,
+                "geometry": c.get("geometry"),
+            }
+        ]
+
+        sections = c.get("sections", [])
+        best_sec_id = None
+        if sections:
+            best_sec = next(
+                (s for s in sections if s.get("relation") == "direct"),
+                next(
+                    (s for s in sections if s.get("relation") == "overlap"), sections[0]
+                ),
             )
-
-        merge_point = None
-        if c.get("geometry_after_wkt"):
-            g_after = wkt.loads(c["geometry_after_wkt"])
-            merge_point = Point(g_after.coords[0])
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": mapping(merge_point),
-                    "properties": {
-                        "id": merge_node_id,
-                        "feature_type": "node",
-                        "node_type": "bridge_merge",
-                        "node_id": merge_node_id,
-                        "bridge_id": bridge_id,
-                    },
-                }
-            )
-
-        if split_point and merge_point and not split_point.equals(merge_point):
-            LineString([split_point, merge_point])
-
-        openings = c.get("openings", [])
-        if not openings:
-            openings = [
-                {
-                    "id": f"virtual_{bridge_id}",
-                    "width": None,
-                    "height": None,
-                    "geometry": c.get("geometry"),
-                }
-            ]
+            best_sec_id = utils.stringify_id(best_sec.get("id"))
 
         for opening in openings:
             op_id = utils.stringify_id(opening["id"])
-
             assert "geometry" in opening and opening["geometry"], (
                 f"Bridge passage opening {op_id} is missing a geometry definition."
             )
-            op_geom_raw = wkt.loads(opening["geometry"])
-            if not isinstance(op_geom_raw, Point):
-                op_geom_raw = op_geom_raw.centroid
-            assert isinstance(op_geom_raw, Point), (
-                f"Bridge passage opening {op_id} could not be resolved to a Point."
+            features.extend(
+                _build_opening_features(
+                    opening,
+                    bridge_id,
+                    op_id,
+                    split_node_id,
+                    merge_node_id,
+                    split_point,
+                    merge_point,
+                    best_sec_id,
+                )
             )
-
-            op_geom = op_geom_raw
-
-            # Calculate orientation and offset points to give the passage a real length
-            azimuth = 0.0
-            if split_point and merge_point and not split_point.equals(merge_point):
-                azimuth, _, _ = geod.inv(
-                    split_point.x, split_point.y, merge_point.x, merge_point.y
-                )
-
-            # Offset 1m back and 1m forward along the azimuth
-            half_len = settings.BRIDGE_PASSAGE_LENGTH_M / 2.0
-            lon1, lat1, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, -half_len)
-            lon2, lat2, _ = geod.fwd(op_geom.x, op_geom.y, azimuth, half_len)
-            op_start_geom = Point(lon1, lat1)
-            op_end_geom = Point(lon2, lat2)
-
-            op_start_node = f"opening_{op_id}_start"
-            op_end_node = f"opening_{op_id}_end"
-
-            sections = c.get("sections", [])
-            best_sec_id = None
-            if sections:
-                best_sec = next(
-                    (s for s in sections if s.get("relation") == "direct"),
-                    next(
-                        (s for s in sections if s.get("relation") == "overlap"),
-                        sections[0],
-                    ),
-                )
-                best_sec_id = utils.stringify_id(best_sec.get("id"))
-
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": mapping(op_start_geom),
-                    "properties": {
-                        "id": op_start_node,
-                        "feature_type": "node",
-                        "node_type": "opening_start",
-                        "node_id": op_start_node,
-                        "bridge_id": bridge_id,
-                        "opening_id": op_id,
-                    },
-                }
-            )
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": mapping(op_end_geom),
-                    "properties": {
-                        "id": op_end_node,
-                        "feature_type": "node",
-                        "node_type": "opening_end",
-                        "node_id": op_end_node,
-                        "bridge_id": bridge_id,
-                        "opening_id": op_id,
-                    },
-                }
-            )
-
-            if split_point:
-                approach_geom = (
-                    LineString([split_point, op_start_geom])
-                    if not split_point.equals(op_start_geom)
-                    else None
-                )
-                features.append(
-                    {
-                        "type": "Feature",
-                        "geometry": mapping(approach_geom) if approach_geom else None,
-                        "properties": {
-                            "id": f"bridge_approach_{bridge_id}_{op_id}",
-                            "feature_type": "fairway_segment",
-                            "segment_type": "bridge_approach",
-                            "structure_type": "bridge",
-                            "structure_id": bridge_id,
-                            "bridge_id": bridge_id,
-                            "opening_id": op_id,
-                            "section_id": best_sec_id,
-                            "source_node": split_node_id,
-                            "target_node": op_start_node,
-                            "length_m": geod.geometry_length(approach_geom)
-                            if approach_geom
-                            else 0.0,
-                        },
-                    }
-                )
-
-            passage_geom = LineString([op_start_geom, op_end_geom])
-
-            # Serialize metadata and handle nominal length
-            op_attrs = {}
-            for k, v in opening.items():
-                if k in ["id", "geometry"]:
-                    continue
-                if isinstance(v, (list, dict)):
-                    op_attrs[k] = json.dumps(v)
-                elif pd.isna(v):
-                    op_attrs[k] = None
-                else:
-                    op_attrs[k] = v
-
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": mapping(passage_geom),
-                    "properties": {
-                        **op_attrs,
-                        "id": f"bridge_passage_{bridge_id}_{op_id}",
-                        "feature_type": "fairway_segment",
-                        "segment_type": "bridge_passage",
-                        "structure_type": "bridge",
-                        "structure_id": bridge_id,
-                        "bridge_id": bridge_id,
-                        "opening_id": op_id,
-                        "section_id": best_sec_id,
-                        "source_node": op_start_node,
-                        "target_node": op_end_node,
-                        "length_m": settings.BRIDGE_PASSAGE_LENGTH_M,  # Nominal length for simulation compatibility
-                    },
-                }
-            )
-
-            if merge_point:
-                exit_geom = (
-                    LineString([op_end_geom, merge_point])
-                    if not op_end_geom.equals(merge_point)
-                    else None
-                )
-                features.append(
-                    {
-                        "type": "Feature",
-                        "geometry": mapping(exit_geom) if exit_geom else None,
-                        "properties": {
-                            "id": f"bridge_exit_{bridge_id}_{op_id}",
-                            "feature_type": "fairway_segment",
-                            "segment_type": "bridge_exit",
-                            "structure_type": "bridge",
-                            "structure_id": bridge_id,
-                            "bridge_id": bridge_id,
-                            "opening_id": op_id,
-                            "section_id": best_sec_id,
-                            "source_node": op_end_node,
-                            "target_node": merge_node_id,
-                            "length_m": geod.geometry_length(exit_geom)
-                            if exit_geom
-                            else 0.0,
-                        },
-                    }
-                )
 
     return features

--- a/fis/core.py
+++ b/fis/core.py
@@ -12,6 +12,67 @@ from fis.lock.core import find_fairway_junctions
 logger = logging.getLogger(__name__)
 
 
+def _collect_lock_complex_geoms(lock, lock_chambers):
+    """Collect lock + chamber geometries for section intersection."""
+    geoms = [lock.geometry] if hasattr(lock, "geometry") and lock.geometry else []
+    if "geometry" in lock_chambers.columns:
+        for _, chamber_row in lock_chambers.iterrows():
+            if pd.isna(chamber_row["geometry"]):
+                continue
+            geoms.append(
+                wkt.loads(chamber_row["geometry"])
+                if isinstance(chamber_row["geometry"], str)
+                else chamber_row["geometry"]
+            )
+    return geoms
+
+
+def _build_chamber_attrs(chamber, chamber_routes):
+    """Build the chamber attribute dict including the virtual route geometry."""
+    route_wkt = None
+    if (
+        "split_point" in chamber_routes
+        and "merge_point" in chamber_routes
+        and "geometry" in chamber
+        and pd.notna(chamber["geometry"])
+    ):
+        chamber_geom = (
+            wkt.loads(chamber["geometry"])
+            if isinstance(chamber["geometry"], str)
+            else chamber["geometry"]
+        )
+        route = LineString(
+            [
+                chamber_routes["split_point"],
+                chamber_geom.centroid,
+                chamber_routes["merge_point"],
+            ]
+        )
+        route_wkt = route.wkt
+
+    chamber_attrs = sanitize_attrs(chamber)
+    chamber_attrs.update(
+        {
+            "id": chamber["id"],
+            "name": chamber["name"],
+            "dim_usable_length": float(chamber["dim_usable_length"])
+            if pd.notna(chamber.get("dim_usable_length"))
+            else None,
+            "dim_gate_width": float(chamber["dim_gate_width"])
+            if pd.notna(chamber.get("dim_gate_width"))
+            else None,
+            "dim_structural_length": float(chamber["dim_structural_length"])
+            if pd.notna(chamber.get("dim_structural_length"))
+            else None,
+            "dim_structural_width": float(chamber["dim_structural_width"])
+            if pd.notna(chamber.get("dim_structural_width"))
+            else None,
+            "route_geometry": route_wkt,
+        }
+    )
+    return chamber_attrs
+
+
 def load_data(export_dir: pathlib.Path):
     """Load necessary parquet files."""
 
@@ -28,7 +89,7 @@ def load_data(export_dir: pathlib.Path):
 
         df = pd.read_parquet(pq)
         if "Geometry" in df.columns and df["Geometry"].dtype == "object":
-            df["geometry"] = df["Geometry"].apply(lambda x: wkt.loads(x) if x else None)
+            df["geometry"] = df["Geometry"].apply(wkt.loads)
             return gpd.GeoDataFrame(df, geometry="geometry")
         return pd.DataFrame(df)
 
@@ -132,23 +193,7 @@ def group_complexes(locks, chambers, isrs, ris_df, fairways, berths, sections):
 
         # Section Overlap Identification
         sections_data = []
-        # Define complex geometry: Union of lock + chambers
-        # Start with lock geometry
-        complex_geoms = (
-            [lock.geometry] if hasattr(lock, "geometry") and lock.geometry else []
-        )
-
-        # Add chamber geometries
-        if "geometry" in lock_chambers.columns:
-            for _, c_row in lock_chambers.iterrows():
-                if pd.isna(c_row["geometry"]):
-                    continue
-                c_geom = (
-                    wkt.loads(c_row["geometry"])
-                    if isinstance(c_row["geometry"], str)
-                    else c_row["geometry"]
-                )
-                complex_geoms.append(c_geom)
+        complex_geoms = _collect_lock_complex_geoms(lock, lock_chambers)
 
         if complex_geoms:
             complex_union = unary_union([g for g in complex_geoms if g])
@@ -185,50 +230,9 @@ def group_complexes(locks, chambers, isrs, ris_df, fairways, berths, sections):
 
         # Add chambers
         for _, chamber in lock_chambers.iterrows():
-            # Add Chamber Route (Virtual Fairway)
-            route_wkt = None
-            if (
-                "split_point" in chamber_routes
-                and "merge_point" in chamber_routes
-                and "geometry" in chamber
-                and pd.notna(chamber["geometry"])
-            ):
-                ch_geom = (
-                    wkt.loads(chamber["geometry"])
-                    if isinstance(chamber["geometry"], str)
-                    else chamber["geometry"]
-                )
-                centroid = ch_geom.centroid
-                route = LineString(
-                    [
-                        chamber_routes["split_point"],
-                        centroid,
-                        chamber_routes["merge_point"],
-                    ]
-                )
-                route_wkt = route.wkt
-
-            chamber_attrs = sanitize_attrs(chamber)
-            chamber_attrs.update(
-                {
-                    "id": chamber["id"],
-                    "name": chamber["name"],
-                    "dim_usable_length": float(chamber["dim_usable_length"])
-                    if pd.notna(chamber.get("dim_usable_length"))
-                    else None,
-                    "dim_gate_width": float(chamber["dim_gate_width"])
-                    if pd.notna(chamber.get("dim_gate_width"))
-                    else None,
-                    "dim_structural_length": float(chamber["dim_structural_length"])
-                    if pd.notna(chamber.get("dim_structural_length"))
-                    else None,
-                    "dim_structural_width": float(chamber["dim_structural_width"])
-                    if pd.notna(chamber.get("dim_structural_width"))
-                    else None,
-                    "route_geometry": route_wkt,
-                }
+            complex_obj["locks"][0]["chambers"].append(
+                _build_chamber_attrs(chamber, chamber_routes)
             )
-            complex_obj["locks"][0]["chambers"].append(chamber_attrs)
 
         complexes.append(complex_obj)
 

--- a/fis/dropins/euris_io.py
+++ b/fis/dropins/euris_io.py
@@ -10,6 +10,58 @@ from fis.utils import normalize_attributes
 logger = logging.getLogger(__name__)
 
 
+def _associate_nodes_with_sections(sections_gdf, nodes_gdf):
+    """Add StartJunctionId/EndJunctionId columns to sections_gdf based on node linkage."""
+    id_col = "id" if "id" in nodes_gdf.columns else "locode"
+    nodes_gdf = nodes_gdf.copy()
+    nodes_gdf["countrycode"] = nodes_gdf[id_col].apply(lambda x: x[:2] if x else "XX")
+    obj_col = "objectcode" if "objectcode" in nodes_gdf.columns else "object_code"
+    nodes_gdf["node_id"] = nodes_gdf.apply(
+        lambda row: f"{row['countrycode']}_{row[obj_col]}", axis=1
+    )
+
+    node_section = sections_gdf[["id"]].merge(
+        nodes_gdf[["section_id", "node_id"]], left_on="id", right_on="section_id"
+    )[["section_id", "node_id"]]
+
+    if node_section.empty:
+        return sections_gdf
+
+    left_df = node_section.groupby("section_id").first()
+    right_df = node_section.groupby("section_id").last()
+    edge_nodes = pd.merge(
+        left_df, right_df, left_index=True, right_index=True, suffixes=["_from", "_to"]
+    )
+    sections_gdf = sections_gdf.merge(
+        edge_nodes.reset_index(), left_on="id", right_on="section_id", how="left"
+    )
+    sections_gdf["StartJunctionId"] = sections_gdf["node_id_from"]
+    sections_gdf["EndJunctionId"] = sections_gdf["node_id_to"]
+    return sections_gdf
+
+
+def _process_euris_chambers(relevant_chambers, lock_chamber_areas_gdf):
+    """Convert chamber dicts to the expected format, matching area geometry where available."""
+    chambers = []
+    for chamber_dict in relevant_chambers:
+        c_geom = chamber_dict["geometry"]
+        if isinstance(c_geom, str):
+            c_geom = wkt.loads(c_geom)
+        chamber_dict["topological_anchor"] = c_geom.wkt
+        area_match_id = chamber_dict.get("id")
+        if not lock_chamber_areas_gdf.empty:
+            areas = lock_chamber_areas_gdf[
+                lock_chamber_areas_gdf["locode"] == area_match_id
+            ]
+            chamber_dict["geometry"] = (
+                areas.iloc[0].geometry.wkt if not areas.empty else c_geom.wkt
+            )
+        else:
+            chamber_dict["geometry"] = c_geom.wkt
+        chambers.append(chamber_dict)
+    return chambers
+
+
 def load_dropins_with_explicit_linking(
     export_dir: pathlib.Path, bbox=None
 ) -> Tuple[List[Dict], List[Dict], List[Dict], List[Dict], pd.DataFrame, pd.DataFrame]:
@@ -39,6 +91,7 @@ def load_dropins_with_explicit_linking(
                     gdfs.append(gdf)
             except Exception as e:
                 logger.error(f"Error reading {f.name}: {e}")
+                raise
         if not gdfs:
             return gpd.GeoDataFrame(columns=["geometry"], crs="EPSG:4326")
 
@@ -84,44 +137,7 @@ def load_dropins_with_explicit_linking(
     # Associate nodes with sections
     if not sections_gdf.empty and not nodes_gdf.empty:
         logger.info("Associating nodes with sections...")
-        # node_id construction logic from fis.graph.euris
-        # In this context, we already normalized nodes_gdf, so locode might be 'id'
-        # but normalize_attributes might have converted 'locode' to 'id'
-        # Let's use the raw column if available or normalized one
-        id_col = "id" if "id" in nodes_gdf.columns else "locode"
-        nodes_gdf["countrycode"] = nodes_gdf[id_col].apply(
-            lambda x: x[:2] if x else "XX"
-        )
-
-        # objectcode might have been normalized to snake_case if not in schema.toml nodes section
-        obj_col = "objectcode" if "objectcode" in nodes_gdf.columns else "object_code"
-        nodes_gdf["node_id"] = nodes_gdf.apply(
-            lambda row: f"{row['countrycode']}_{row[obj_col]}", axis=1
-        )
-
-        node_section = sections_gdf[["id"]].merge(
-            nodes_gdf[["section_id", "node_id"]], left_on="id", right_on="section_id"
-        )[["section_id", "node_id"]]
-
-        if not node_section.empty:
-            left_df = node_section.groupby("section_id").first()
-            right_df = node_section.groupby("section_id").last()
-
-            edge_nodes = pd.merge(
-                left_df,
-                right_df,
-                left_index=True,
-                right_index=True,
-                suffixes=["_from", "_to"],
-            )
-            sections_gdf = sections_gdf.merge(
-                edge_nodes.reset_index(),
-                left_on="id",
-                right_on="section_id",
-                how="left",
-            )
-            sections_gdf["StartJunctionId"] = sections_gdf["node_id_from"]
-            sections_gdf["EndJunctionId"] = sections_gdf["node_id_to"]
+        sections_gdf = _associate_nodes_with_sections(sections_gdf, nodes_gdf)
 
     # 1. Group Locks
     logger.info("Grouping Locks (Explicit)...")
@@ -163,33 +179,9 @@ def load_dropins_with_explicit_linking(
         complex_dict["geometry"] = complex_row.geometry.wkt
 
         # Chambers
-        chambers = []
-        relevant_chambers = chambers_by_parent.get(cid, [])
-        for chamber_dict in relevant_chambers:
-            # Ensure geometry is a shapely object if it came from to_dict
-            c_geom = chamber_dict["geometry"]
-            if isinstance(c_geom, str):
-                c_geom = wkt.loads(c_geom)
-
-            # Preserve the Point geometry for splicing (Topological Anchor)
-            chamber_dict["topological_anchor"] = c_geom.wkt
-
-            # Match Area for visualization
-            # Use raw 'locode' for area matching if available, otherwise 'id'
-            area_match_id = chamber_dict.get("id")
-            if not lock_chamber_areas_gdf.empty:
-                # lock_chamber_areas_gdf wasn't normalized, so it has 'locode'
-                areas = lock_chamber_areas_gdf[
-                    lock_chamber_areas_gdf["locode"] == area_match_id
-                ]
-                if not areas.empty:
-                    chamber_dict["geometry"] = areas.iloc[0].geometry.wkt
-                else:
-                    chamber_dict["geometry"] = c_geom.wkt
-            else:
-                chamber_dict["geometry"] = c_geom.wkt
-
-            chambers.append(chamber_dict)
+        chambers = _process_euris_chambers(
+            chambers_by_parent.get(cid, []), lock_chamber_areas_gdf
+        )
 
         complex_dict["locks"] = [{"chambers": chambers}]
         lock_complexes.append(complex_dict)

--- a/fis/dropins/splicing.py
+++ b/fis/dropins/splicing.py
@@ -167,17 +167,19 @@ def _slice_section_with_dropins(
     all_features, sec, visible_dropins, original_dropins_on_sec, mode="detailed"
 ):
     line_geom = sec.geometry
+    projected_crs = settings.PROJECTED_CRS
     line_rd_series = gpd.GeoSeries([line_geom], crs="EPSG:4326")
-    utm_crs = line_rd_series.estimate_utm_crs()
-    line_rd = line_rd_series.to_crs(utm_crs).iloc[0]
+    line_rd = line_rd_series.to_crs(projected_crs).iloc[0]
 
     splicer = FairwaySplicer(line_rd)
-    cuts = _generate_structure_cuts(line_rd, visible_dropins, utm_crs, mode=mode)
+    cuts = _generate_structure_cuts(line_rd, visible_dropins, projected_crs, mode=mode)
     segments = splicer.splice(cuts)
 
     for i, segment in enumerate(segments):
         seg_4326 = (
-            gpd.GeoSeries([segment.geometry], crs=utm_crs).to_crs("EPSG:4326").iloc[0]
+            gpd.GeoSeries([segment.geometry], crs=projected_crs)
+            .to_crs("EPSG:4326")
+            .iloc[0]
         )
         source_node, is_start_junc = _determine_source_node(
             segment, sec.get("StartJunctionId"), original_dropins_on_sec, seg_4326
@@ -264,7 +266,7 @@ def _determine_target_node(
 
 
 def _generate_structure_cuts(
-    line_rd: Any, dropins_on_sec: List[Dict], utm_crs: str, mode: str = "detailed"
+    line_rd: Any, dropins_on_sec: List[Dict], projected_crs: str, mode: str = "detailed"
 ) -> List[StructureCut]:
     cuts = []
     for dropin in dropins_on_sec:
@@ -279,7 +281,7 @@ def _generate_structure_cuts(
             )
 
         geom = wkt.loads(geom_val) if isinstance(geom_val, str) else geom_val
-        geom_rd = gpd.GeoSeries([geom], crs="EPSG:4326").to_crs(utm_crs).iloc[0]
+        geom_rd = gpd.GeoSeries([geom], crs="EPSG:4326").to_crs(projected_crs).iloc[0]
         if geom_rd.geom_type != "Point":
             geom_rd = geom_rd.centroid
 

--- a/fis/graph/validation.py
+++ b/fis/graph/validation.py
@@ -11,6 +11,34 @@ import jinja2
 logger = logging.getLogger(__name__)
 
 
+def _check_compliance_for_elements(data_iter, canonical_attrs, schema):
+    non_compliant = {}
+    missing_counts = {k: 0 for k in canonical_attrs}
+    attribute_docs = {
+        k: "Mapped from " + str([old for old, new in schema.items() if new == k])
+        for k in canonical_attrs
+        if k in schema.values()
+    }
+    for k in canonical_attrs:
+        if k not in attribute_docs:
+            attribute_docs[k] = "Standard/Base Attribute"
+
+    for d in data_iter:
+        for k in d.keys():
+            if k not in canonical_attrs and k not in schema:
+                if any(x.isupper() for x in k) and k != "geometry":
+                    non_compliant[k] = non_compliant.get(k, 0) + 1
+        for k in canonical_attrs:
+            if k not in d or d[k] is None or d[k] == "":
+                missing_counts[k] += 1
+
+    return {
+        "non_compliant": non_compliant,
+        "missing_counts": missing_counts,
+        "attribute_docs": attribute_docs,
+    }
+
+
 class GraphValidator:
     """Validator for FIS-EURIS merged graph."""
 
@@ -214,8 +242,9 @@ class GraphValidator:
         """Check if attributes comply with schema and track completeness."""
         logger.info("Checking schema compliance...")
 
-        node_schema = self.schema.get("attributes", {}).get("nodes", {})
-        edge_schema = self.schema.get("attributes", {}).get("edges", {})
+        attr_schema = self.schema.get("attributes", {})
+        node_schema = attr_schema.get("nodes", {})
+        edge_schema = attr_schema.get("edges", {})
 
         canonical_node_attrs = set(node_schema.values()) | {
             "data_source",
@@ -232,70 +261,34 @@ class GraphValidator:
             "connection_type",
         }
 
-        non_compliant_node_keys = {}
-        node_missing_counts = {k: 0 for k in canonical_node_attrs}
-        node_attribute_docs = {
-            k: "Mapped from "
-            + str([old for old, new in node_schema.items() if new == k])
-            for k in canonical_node_attrs
-            if k in node_schema.values()
-        }
-        for k in canonical_node_attrs:
-            if k not in node_attribute_docs:
-                node_attribute_docs[k] = "Standard/Base Attribute"
+        node_data = (d for _, d in self.graph.nodes(data=True))
+        edge_data = (d for _, _, d in self.graph.edges(data=True))
 
-        for n, d in self.graph.nodes(data=True):
-            for k in d.keys():
-                if k not in canonical_node_attrs and k not in node_schema:
-                    if any(x.isupper() for x in k) and k != "geometry":
-                        non_compliant_node_keys[k] = (
-                            non_compliant_node_keys.get(k, 0) + 1
-                        )
-            for k in canonical_node_attrs:
-                if k not in d or d[k] is None or d[k] == "":
-                    node_missing_counts[k] += 1
-
-        non_compliant_edge_keys = {}
-        edge_missing_counts = {k: 0 for k in canonical_edge_attrs}
-        edge_attribute_docs = {
-            k: "Mapped from "
-            + str([old for old, new in edge_schema.items() if new == k])
-            for k in canonical_edge_attrs
-            if k in edge_schema.values()
-        }
-        for k in canonical_edge_attrs:
-            if k not in edge_attribute_docs:
-                edge_attribute_docs[k] = "Standard/Base Attribute"
-
-        for u, v, d in self.graph.edges(data=True):
-            for k in d.keys():
-                if k not in canonical_edge_attrs and k not in edge_schema:
-                    if any(x.isupper() for x in k) and k != "geometry":
-                        non_compliant_edge_keys[k] = (
-                            non_compliant_edge_keys.get(k, 0) + 1
-                        )
-            for k in canonical_edge_attrs:
-                if k not in d or d[k] is None or d[k] == "":
-                    edge_missing_counts[k] += 1
+        node_result = _check_compliance_for_elements(
+            node_data, canonical_node_attrs, node_schema
+        )
+        edge_result = _check_compliance_for_elements(
+            edge_data, canonical_edge_attrs, edge_schema
+        )
 
         compliance = {
             "nodes": {
                 "non_standard_attributes_detected": list(
-                    non_compliant_node_keys.keys()
+                    node_result["non_compliant"].keys()
                 ),
-                "attribute_counts": non_compliant_node_keys,
-                "missing_counts": node_missing_counts,
+                "attribute_counts": node_result["non_compliant"],
+                "missing_counts": node_result["missing_counts"],
                 "expected_attributes": list(canonical_node_attrs),
-                "attribute_docs": node_attribute_docs,
+                "attribute_docs": node_result["attribute_docs"],
             },
             "edges": {
                 "non_standard_attributes_detected": list(
-                    non_compliant_edge_keys.keys()
+                    edge_result["non_compliant"].keys()
                 ),
-                "attribute_counts": non_compliant_edge_keys,
-                "missing_counts": edge_missing_counts,
+                "attribute_counts": edge_result["non_compliant"],
+                "missing_counts": edge_result["missing_counts"],
                 "expected_attributes": list(canonical_edge_attrs),
-                "attribute_docs": edge_attribute_docs,
+                "attribute_docs": edge_result["attribute_docs"],
             },
         }
         self.results["schema_compliance"] = compliance

--- a/fis/ivs/assign.py
+++ b/fis/ivs/assign.py
@@ -234,23 +234,8 @@ def build_edge_structures_lookup() -> dict:
     return lookup
 
 
-def check_edge_constraints_soft(d_edge: dict, struct_data: dict, ship_dims: dict):
-    """
-    Evaluates physical constraints of the edge and outputs heuristic penalties and violations.
-    """
-    penalties = {
-        "lock": 0.0,
-        "bridge": 0.0,
-        "fairway": 0.0,
-        "sea": 0.0,
-        "cemt": 0.0,
-        "total": 0.0,
-    }
-    violations = []
-
-    chambers = struct_data.get("chambers", [])
-    openings = struct_data.get("openings", [])
-
+def _find_min_width(chambers, openings, d_edge):
+    """Return (min_width, limiting_struct) across chambers, bridge openings, and the edge."""
     min_width = 999.0
     limiting_struct = None
 
@@ -276,6 +261,40 @@ def check_edge_constraints_soft(d_edge: dict, struct_data: dict, ship_dims: dict
                 d_edge.get("name", "Fairway"),
                 "fairway",
             )
+
+    return min_width, limiting_struct
+
+
+def _find_min_length(chambers):
+    """Return (min_length, limiting_chamber) across lock chambers."""
+    min_len = 999.0
+    limiting_ch = None
+    for ch in chambers:
+        ch_length = ch.get("dim_usable_length", ch.get("length"))
+        if is_valid(ch_length) and float(ch_length) < min_len:
+            min_len = float(ch_length)
+            limiting_ch = (ch.get("id"), ch.get("name", "Lock Chamber"))
+    return min_len, limiting_ch
+
+
+def check_edge_constraints_soft(d_edge: dict, struct_data: dict, ship_dims: dict):
+    """
+    Evaluates physical constraints of the edge and outputs heuristic penalties and violations.
+    """
+    penalties = {
+        "lock": 0.0,
+        "bridge": 0.0,
+        "fairway": 0.0,
+        "sea": 0.0,
+        "cemt": 0.0,
+        "total": 0.0,
+    }
+    violations = []
+
+    chambers = struct_data.get("chambers", [])
+    openings = struct_data.get("openings", [])
+
+    min_width, limiting_struct = _find_min_width(chambers, openings, d_edge)
 
     if ship_dims["beam"] > min_width:
         struct_id = limiting_struct[0] if limiting_struct else None
@@ -306,13 +325,7 @@ def check_edge_constraints_soft(d_edge: dict, struct_data: dict, ship_dims: dict
             }
         )
 
-    min_len = 999.0
-    limiting_ch = None
-    for ch in chambers:
-        ch_length = ch.get("dim_usable_length", ch.get("length"))
-        if is_valid(ch_length) and float(ch_length) < min_len:
-            min_len = float(ch_length)
-            limiting_ch = (ch.get("id"), ch.get("name", "Lock Chamber"))
+    min_len, limiting_ch = _find_min_length(chambers)
 
     if limiting_ch and ship_dims["length"] > min_len:
         penalties["lock"] += 1000.0

--- a/fis/lock/core.py
+++ b/fis/lock/core.py
@@ -15,6 +15,20 @@ from fis.ris_index import load_ris_index
 logger = logging.getLogger(__name__)
 
 
+def _collect_complex_geoms(lock, lock_chambers):
+    """Collect lock + chamber geometries for spatial matching."""
+    geoms = [lock.geometry] if hasattr(lock, "geometry") and lock.geometry else []
+    if not lock_chambers.empty and "geometry" in lock_chambers.columns:
+        for _, c_row in lock_chambers.iterrows():
+            if pd.notna(c_row["geometry"]):
+                geoms.append(
+                    wkt.loads(c_row["geometry"])
+                    if isinstance(c_row["geometry"], str)
+                    else c_row["geometry"]
+                )
+    return geoms
+
+
 def load_data(export_dir: pathlib.Path, disk_dir: pathlib.Path):
     """Load necessary parquet files and normalize attributes."""
 
@@ -491,18 +505,7 @@ def _find_connected_sections_optimized(
                             connected_fairways.add(stringify_id(fid_val))
 
     # 3. Spatial matching using pre-built spatial index
-    complex_geoms = (
-        [lock.geometry] if hasattr(lock, "geometry") and lock.geometry else []
-    )
-    if not lock_chambers.empty and "geometry" in lock_chambers.columns:
-        for _, c_row in lock_chambers.iterrows():
-            if pd.notna(c_row["geometry"]):
-                c_geom = (
-                    wkt.loads(c_row["geometry"])
-                    if isinstance(c_row["geometry"], str)
-                    else c_row["geometry"]
-                )
-                complex_geoms.append(c_geom)
+    complex_geoms = _collect_complex_geoms(lock, lock_chambers)
 
     if complex_geoms:
         complex_union = unary_union([g for g in complex_geoms if g])

--- a/fis/pipelines.py
+++ b/fis/pipelines.py
@@ -107,14 +107,7 @@ class EurisFilesPipeline(FilesPipeline):
         ris_dfs = []
         for excel_file in tqdm(excel_files, desc="Processing RIS Excel files"):
             spider.logger.info(f"Reading {excel_file}")
-            # Use calamine engine for much faster excel reading if available
-            try:
-                df = pd.read_excel(excel_file, engine="calamine")
-            except Exception as e:
-                spider.logger.warning(
-                    f"Calamine engine failed for {excel_file}, falling back: {e}"
-                )
-                df = pd.read_excel(excel_file)
+            df = pd.read_excel(excel_file, engine="calamine")
 
             if df.empty:
                 continue

--- a/fis/settings.py
+++ b/fis/settings.py
@@ -120,9 +120,16 @@ if _raw_version_for_paths == "unknown":
 VERSION = _raw_version_for_paths.split("+", 1)[0]
 # --- Graph Integration & Splicing Parameters ---
 
-# Coordinate Reference System for Projected/Metric Operations
-# Used for all metric calculations (distance, area, splicing).
-# TODO: Replace with dynamic estimation (e.g., estimate_utm_crs) for non-NL support.
+# Coordinate Reference System for projected/metric operations (distance, area, splicing).
+#
+# EPSG:28992  RD New (Rijksdriehoek) — conformal Stereographic, accurate for distances
+#             and angles across the Netherlands. Default and recommended for NL data.
+#
+# EPSG:3035   ETRS89-LAEA — equal-area, used by Eurostat/EEA for EU-wide datasets.
+#             Suitable for area comparisons across the EU, but NOT for precise distance
+#             measurements: the projection centre is at 52°N 10°E and the Netherlands
+#             sits ~500 km west of it, giving a typical distance error of ~0.5% (~5 m/km).
+#             Angles and shapes are also distorted.
 PROJECTED_CRS = "EPSG:28992"
 
 # --- Splicing Buffers (Meters) ---

--- a/fis/utils.py
+++ b/fis/utils.py
@@ -17,6 +17,66 @@ from fis import settings
 logger = logging.getLogger(__name__)
 
 
+def _build_disallowed_mask(disallowed_sections, sections_gdf):
+    """Return a buffered union of disallowed section geometries, or None."""
+    if not disallowed_sections or sections_gdf is None:
+        return None
+    from shapely.ops import unary_union
+
+    disallowed_geoms = sections_gdf[
+        sections_gdf["id"].isin(disallowed_sections)
+    ].geometry.tolist()
+    if not disallowed_geoms:
+        return None
+    return unary_union(disallowed_geoms).buffer(
+        settings.BERTH_INTERNAL_SECTION_BUFFER_DEG
+    )
+
+
+def _parse_line_geom(geom):
+    """Parse a WKT string or LineString to a LineString, or return None."""
+    from shapely.geometry import LineString
+
+    if isinstance(geom, str):
+        return wkt.loads(geom)
+    if isinstance(geom, LineString):
+        return geom
+    return None
+
+
+def _collect_berth_attrs(berth, geom_before, geom_after, dist_m):
+    """Build the berth result dict with scalar attributes, relation, and distance."""
+    relation = "unknown"
+    if geom_before and geom_after and berth.geometry:
+        if geom_before.distance(berth.geometry) < geom_after.distance(berth.geometry):
+            relation = "before"
+        else:
+            relation = "after"
+
+    berth_attrs = {}
+    for k, v in berth.to_dict().items():
+        if k == "geometry":
+            continue
+        try:
+            if isinstance(v, (list, dict, pd.Series, pd.Index, np.ndarray)):
+                berth_attrs[k] = v
+            elif pd.notna(v):
+                berth_attrs[k] = v
+        except (ValueError, TypeError):
+            berth_attrs[k] = v
+
+    berth_attrs.update(
+        {
+            "geometry": berth.geometry.wkt
+            if hasattr(berth, "geometry") and berth.geometry
+            else None,
+            "relation": relation,
+            "dist_m": round(dist_m, 1) if dist_m is not None else None,
+        }
+    )
+    return berth_attrs
+
+
 def timer(func: Callable) -> Callable:
     """Decorator to log the execution time of a function."""
 
@@ -393,7 +453,7 @@ def find_nearby_berths(
     lock_geom = lock_row.geometry if hasattr(lock_row, "geometry") else None
     if not lock_geom:
         return nearby
-    lg = lock_geom if isinstance(lock_geom, Point) else lock_geom.centroid
+    lock_point = lock_geom if isinstance(lock_geom, Point) else lock_geom.centroid
 
     # 1. Spatial pre-filter using spatial index (if available)
     # Buffer in degrees (approximate) for the spatial query
@@ -402,7 +462,7 @@ def find_nearby_berths(
         # Use 80000 instead of 111000 to be more generous at higher latitudes (like NL)
         buffer_deg = max_dist_m / 80000.0
         possible_matches_index = candidates.sindex.query(
-            lg.buffer(buffer_deg), predicate="intersects"
+            lock_point.buffer(buffer_deg), predicate="intersects"
         )
         candidates = candidates.iloc[possible_matches_index]
 
@@ -410,36 +470,9 @@ def find_nearby_berths(
         return nearby
 
     geod = Geod(ellps="WGS84")
-
-    # Handle disallowed sections (inside lock)
-    disallowed_mask = None
-    if disallowed_sections and sections_gdf is not None:
-        from shapely.ops import unary_union
-
-        invalid_mask = sections_gdf["id"].isin(disallowed_sections)
-        disallowed_geoms = sections_gdf[invalid_mask].geometry.tolist()
-        if disallowed_geoms:
-            disallowed_mask = unary_union(disallowed_geoms).buffer(
-                settings.BERTH_INTERNAL_SECTION_BUFFER_DEG
-            )
-
-    # Pre-parse fairway geometries
-    from shapely.geometry import LineString
-
-    g_before = (
-        wkt.loads(fairway_geom_before)
-        if isinstance(fairway_geom_before, str)
-        else fairway_geom_before
-        if isinstance(fairway_geom_before, LineString)
-        else None
-    )
-    g_after = (
-        wkt.loads(fairway_geom_after)
-        if isinstance(fairway_geom_after, str)
-        else fairway_geom_after
-        if isinstance(fairway_geom_after, LineString)
-        else None
-    )
+    disallowed_mask = _build_disallowed_mask(disallowed_sections, sections_gdf)
+    geom_before = _parse_line_geom(fairway_geom_before)
+    geom_after = _parse_line_geom(fairway_geom_after)
 
     for _, berth in candidates.iterrows():
         is_nearby = False
@@ -448,60 +481,26 @@ def find_nearby_berths(
         if not berth.geometry:
             continue
 
-        if disallowed_mask:
-            if disallowed_mask.intersects(berth.geometry):
-                continue
+        if disallowed_mask and disallowed_mask.intersects(berth.geometry):
+            continue
 
-        lg = lock_geom if isinstance(lock_geom, Point) else lock_geom.centroid
-        bg = (
+        berth_point = (
             berth.geometry
             if isinstance(berth.geometry, Point)
             else berth.geometry.centroid
         )
 
-        if lg and bg:
-            _, _, dist_m = geod.inv(lg.x, lg.y, bg.x, bg.y)
+        if lock_point and berth_point:
+            _, _, dist_m = geod.inv(
+                lock_point.x, lock_point.y, berth_point.x, berth_point.y
+            )
             if dist_m <= max_dist_m:
                 is_nearby = True
 
         if not is_nearby:
             continue
 
-        # Determine relation (before/after)
-        relation = "unknown"
-        if g_before and g_after and berth.geometry:
-            if g_before.distance(berth.geometry) < g_after.distance(berth.geometry):
-                relation = "before"
-            else:
-                relation = "after"
-
-        # Propagate ALL scalar attributes
-        b_obj = {}
-        for k, v in berth.to_dict().items():
-            if k == "geometry":
-                continue
-
-            # Use a robust way to check for NA on potentially complex types
-            try:
-                if isinstance(v, (list, dict, pd.Series, pd.Index, np.ndarray)):
-                    # Keep complex types as-is (might be problematic for downstream but avoids error)
-                    b_obj[k] = v
-                elif pd.notna(v):
-                    b_obj[k] = v
-            except (ValueError, TypeError):
-                # If truth value is still ambiguous, just include it to be safe
-                b_obj[k] = v
-
-        b_obj.update(
-            {
-                "geometry": berth.geometry.wkt
-                if hasattr(berth, "geometry") and berth.geometry
-                else None,
-                "relation": relation,
-                "dist_m": round(dist_m, 1) if dist_m is not None else None,
-            }
-        )
-        nearby.append(b_obj)
+        nearby.append(_collect_berth_attrs(berth, geom_before, geom_after, dist_m))
 
     return nearby
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "ipdb>=0.13.13",
     "pytest>=9.0.3",
     "jupyterlab>=4.4.3",
+    "radon>=6.0.1",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -679,6 +679,7 @@ dev = [
     { name = "ipdb" },
     { name = "jupyterlab" },
     { name = "pytest" },
+    { name = "radon" },
 ]
 
 [package.metadata]
@@ -711,6 +712,7 @@ dev = [
     { name = "ipdb", specifier = ">=0.13.13" },
     { name = "jupyterlab", specifier = ">=4.4.3" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "radon", specifier = ">=6.0.1" },
 ]
 
 [[package]]
@@ -1468,6 +1470,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
     { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
     { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
+name = "mando"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
 ]
 
 [[package]]
@@ -2595,6 +2609,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/f3/d80ab8c7c91b8c42d9a2aa4dd97a8be1321e7b26000c2675b75e641d958c/queuelib-1.9.0.tar.gz", hash = "sha256:b12fea79fd8c1dd23e212b1f3db58003b773949801d4f4e6f34d882467d4a192", size = 11729, upload-time = "2026-01-29T11:19:37.065Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/1c/8df7b461497b42fcc1e7c44529201975ec77b0e1ebecd00df4b1f096c1d4/queuelib-1.9.0-py3-none-any.whl", hash = "sha256:c5fd3bebf2c924446fa94fca6b72e81168f79cf4c2a9143b8b26f266a423fcf3", size = 13585, upload-time = "2026-01-29T11:19:35.616Z" },
+]
+
+[[package]]
+name = "radon"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "mando" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #130 (partial — scoped to complexity, error handling, CRS consistency, and CI).

## Summary

- **Radon in CI**: Added reporting-only complexity job (no threshold yet) and `radon` dev dependency so we can track trends over time.
- **CRS consistency**: `splicing.py` was using `estimate_utm_crs()` (dynamic UTM) while every other module uses `settings.PROJECTED_CRS` (EPSG:28992 RD New). Now unified. `settings.py` documents both EPSG:28992 and EPSG:3035 (ETRS89-LAEA, EU equal-area) with trade-offs — the latter has ~0.5% distance error (~5 m/km) for NL since the projection centre is at 52°N 10°E.
- **Silent errors removed**: `euris_io.py` re-raises after logging; `pipelines.py` calamine fallback removed (pick an engine, fix it if it breaks, no silent degradation); `core.py` falsy geometry guard removed so bad data raises.
- **Complexity**: All F- and E-grade functions eliminated by extracting focused helpers. Worst was `find_nearby_berths` F(44) → D(25). All 95 tests pass.
- **Naming**: Renamed cryptic short variables (`lg`, `bg`, `b_obj`, `g_before`/`g_after`) to descriptive names per PEP 8.

## Complexity before → after

| Function | Before | After |
|---|---|---|
| `find_nearby_berths` | F (44) | D (25) |
| `check_schema_compliance` | E (37) | C (19) via helper |
| `load_dropins_with_explicit_linking` | E (35) | D (27) |
| `_find_connected_sections_optimized` | E (33) | D (26) |
| `group_complexes` (core.py) | E (32) | C (17) |
| `build_graph_features` (bridge) | E (32) | C (19) via helper |
| `check_edge_constraints_soft` | E (31) | C (19) |

## Out of scope (separate PR)

The 27 `wkt.loads()` call sites are not just a naming issue — geometries are already parsed correctly at load boundaries. The scatter exists because `sanitize_attrs()` deliberately converts Shapely → WKT for JSON serialisation. The fix is to extend `NumpyEncoder` to handle Shapely objects, which is a larger refactor.

## Test plan

- [x] `uv run pytest tests/` — 95/95 passing
- [x] `uvx ruff check fis/ tests/` — clean
- [x] `uv run radon cc fis/ -s -n C` — no F or E grade functions remain